### PR TITLE
Make tests match readme

### DIFF
--- a/rna-transcription/example.erl
+++ b/rna-transcription/example.erl
@@ -4,7 +4,11 @@
 to_rna(Strand) ->
   lists:map(fun transcribe_to_rna/1, Strand).
 
+transcribe_to_rna($G) ->
+     $C;
+transcribe_to_rna($C) ->
+     $G;
 transcribe_to_rna($T) ->
-     $U;
-transcribe_to_rna(Nucleotide) ->
-    Nucleotide.
+     $A;
+transcribe_to_rna($A) ->
+     $U.

--- a/rna-transcription/rna_transcription_test.erl
+++ b/rna-transcription/rna_transcription_test.erl
@@ -2,19 +2,19 @@
 -include_lib("eunit/include/eunit.hrl").
 
 transcribes_cytidine_unchanged_test() ->
-  ?assertEqual("C", dna:to_rna("C")).
+  ?assertEqual("C", dna:to_rna("G")).
 
 transcribes_guanosine_unchanged_test() ->
-  ?assertEqual("G", dna:to_rna("G")).
+  ?assertEqual("G", dna:to_rna("C")).
 
 transcribes_adenosine_unchanged_test() ->
-  ?assertEqual("A", dna:to_rna("A")).
+  ?assertEqual("A", dna:to_rna("T")).
 
 transcribes_thymidine_to_uracil_test() ->
-  ?assertEqual("U", dna:to_rna("T")).
+  ?assertEqual("U", dna:to_rna("A")).
 
 transcribes_all_occurences_test() ->
   ?assertEqual(
-      "ACGUGGUCUUAA",
+      "UGCACCAGAAUU",
       dna:to_rna("ACGTGGTCTTAA")
   ).


### PR DESCRIPTION
I think this exercise must have been written before the mistake was spotted in the RNA transcription exercise definition a while ago, and as the readme is centralised (and fixed) the tests specify different behaviour to the readme. This change makes the tests match the correct behaviour as specified in the readme. 
