### PR TITLE
Hamming Distance Test Case

### DIFF
--- a/point-mutations/dna_tests.erl
+++ b/point-mutations/dna_tests.erl
@@ -3,22 +3,22 @@
 -include_lib("eunit/include/eunit.hrl").
 
 empty_test()->
-        ?assertEqual(dna:hamming("", ""), 0).
+        ?assertEqual(dna:hammingDistance("", ""), 0).
 
 equal_test() ->
-    ?assertEqual(dna:hamming("GAGCCTACTAACGGGAT", "GAGCCTACTAACGGGAT"), 0).
+    ?assertEqual(dna:hammingDistance("GAGCCTACTAACGGGAT", "GAGCCTACTAACGGGAT"), 0).
 
 all_different_test() ->
-    ?assertEqual(dna:hamming("GAGCCTACTAACGGGAT", "FFFFFFFFFFFFFFFFF"), 17).
+    ?assertEqual(dna:hammingDistance("GAGCCTACTAACGGGAT", "FFFFFFFFFFFFFFFFF"), 17).
 
 ends_different_test()->
-        ?assertEqual(dna:hamming("GAGCCTACTAACGGGAT", "TAGCCTACTAACGGGAG"), 2).
+        ?assertEqual(dna:hammingDistance("GAGCCTACTAACGGGAT", "TAGCCTACTAACGGGAG"), 2).
 
 middle_different_test() ->
-    ?assertEqual(dna:hamming("GAGCCTACTAACGGGAT", "GAGCCTACCAACGGGAT"), 1).
+    ?assertEqual(dna:hammingDistance("GAGCCTACTAACGGGAT", "GAGCCTACCAACGGGAT"), 1).
 
 some_differences_test() ->
-    ?assertEqual(dna:hamming("GAGCCTACTAACGGGAT", "GAACCTCCCAAGGGATT"), 6).
+    ?assertEqual(dna:hammingDistance("GAGCCTACTAACGGGAT", "GAACCTCCCAAGGGATT"), 6).
 
 
 


### PR DESCRIPTION
Does not test sequences of different lengths since the README indicates that it may be assumed that the sequences are of equal length.
