### PR TITLE
Add solution for hamming_distance back into example.erl

### DIFF
--- a/point-mutations/dna_tests.erl
+++ b/point-mutations/dna_tests.erl
@@ -3,24 +3,19 @@
 -include_lib("eunit/include/eunit.hrl").
 
 empty_test()->
-        ?assertEqual(dna:hammingDistance("", ""), 0).
+        ?assertEqual(dna:hamming_distance("", ""), 0).
 
 equal_test() ->
-    ?assertEqual(dna:hammingDistance("GAGCCTACTAACGGGAT", "GAGCCTACTAACGGGAT"), 0).
+    ?assertEqual(dna:hamming_distance("GAGCCTACTAACGGGAT", "GAGCCTACTAACGGGAT"), 0).
 
 all_different_test() ->
-    ?assertEqual(dna:hammingDistance("GAGCCTACTAACGGGAT", "FFFFFFFFFFFFFFFFF"), 17).
+    ?assertEqual(dna:hamming_distance("GAGCCTACTAACGGGAT", "FFFFFFFFFFFFFFFFF"), 17).
 
 ends_different_test()->
-        ?assertEqual(dna:hammingDistance("GAGCCTACTAACGGGAT", "TAGCCTACTAACGGGAG"), 2).
+        ?assertEqual(dna:hamming_distance("GAGCCTACTAACGGGAT", "TAGCCTACTAACGGGAG"), 2).
 
 middle_different_test() ->
-    ?assertEqual(dna:hammingDistance("GAGCCTACTAACGGGAT", "GAGCCTACCAACGGGAT"), 1).
+    ?assertEqual(dna:hamming_distance("GAGCCTACTAACGGGAT", "GAGCCTACCAACGGGAT"), 1).
 
 some_differences_test() ->
-    ?assertEqual(dna:hammingDistance("GAGCCTACTAACGGGAT", "GAACCTCCCAAGGGATT"), 6).
-
-
-
-
-    
+    ?assertEqual(dna:hamming_distance("GAGCCTACTAACGGGAT", "GAACCTCCCAAGGGATT"), 6).

--- a/point-mutations/example.erl
+++ b/point-mutations/example.erl
@@ -1,6 +1,12 @@
 -module(dna).
 
--export([hammingDistance/2]).
+-export([hamming_distance/2]).
 
-hammingDistance(_, _) ->
-    0.
+hamming_distance(From, To) ->
+    Comparisons = lists:zipwith(fun(X,Y) -> case X =:= Y of
+                                          true -> 0;
+                                          false -> 1
+                                      end
+                          end,
+                          From, To),
+    lists:sum(Comparisons).


### PR DESCRIPTION
The haming_distance implementation got lost somewhere along the line, rebase perhaps?

Also changed the test to expect `hamming_distance` as the function name, snake_case is the erlang convention. 

@kytrinyx For https://github.com/exercism/xerlang/issues/22, we're currently trimming the lists so they are of equal length. Instead we should probably just accept different length lists and complain loudly when they're not equal. e.g.

``` erlang
-module(dna).
-export([hamming_distance/2]).

hamming_distance(From, To) ->
    Comparisons = lists:zipwith(fun(X,Y) -> case X =:= Y of
                                          true -> 0;
                                          false -> 1
                                      end
                          end,
                          From, To),
    lists:sum(Comparisons).
```

gives the following when the lists aren't equal in length.

```
module 'dna_tests'
  dna_tests: empty_test...*failed*
in function lists:zipwith/3 (lists.erl, line 449)
  called as zipwith(#Fun<dna.0.66846798>,[],"GAG")
in call from dna:hamming_distance/2 (dna.erl, line 9)
in call from dna_tests:empty_test/0 (dna_tests.erl, line 6)
**error:function_clause
```
