### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# xErlang
+# Exercism Erlang Track
 
-[![Join the chat at https://gitter.im/exercism/xerlang](https://badges.gitter.im/exercism/xerlang.svg)](https://gitter.im/exercism/xerlang?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://gitter.im/exercism/erlang](https://badges.gitter.im/exercism/erlang.svg)](https://gitter.im/exercism/erlang?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Exercism exercises in Erlang
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "erlang",
   "language": "Erlang",
-  "repository": "https://github.com/exercism/xerlang",
+  "repository": "https://github.com/exercism/erlang",
   "active": true,
   "exercises": [
     {
@@ -27,7 +27,7 @@
     },
     {
       "slug": "collatz-conjecture",
-      "topics":[
+      "topics": [
 
       ],
       "difficulty": 1


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1