### PR TITLE
Generate exercise READMEs from templates

### DIFF
--- a/exercises/accumulate/.meta/readme.go.tmpl
+++ b/exercises/accumulate/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -1,0 +1,79 @@
+# Accumulate
+
+Implement the `accumulate` operation, which, given a collection and an
+operation to perform on each element of the collection, returns a new
+collection containing the result of applying that operation to each element of
+the input collection.
+
+Given the collection of numbers:
+
+- 1, 2, 3, 4, 5
+
+And the operation:
+
+- square a number (`x => x * x`)
+
+Your code should be able to produce the collection of squares:
+
+- 1, 4, 9, 16, 25
+
+Check out the test suite to see the expected function signature.
+
+## Restrictions
+
+Keep your hands off that collect/map/fmap/whatchamacallit functionality
+provided by your standard library!
+Solve this one yourself using other basic tools instead.
+
+Lisp specific: it's perfectly fine to use `MAPCAR` or the equivalent,
+as this is idiomatic Lisp, not a library function.
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Conversation with James Edward Gray II [https://twitter.com/jeg2](https://twitter.com/jeg2)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/all-your-base/.meta/readme.go.tmpl
+++ b/exercises/all-your-base/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -1,0 +1,79 @@
+# All Your Base
+
+Convert a number, represented as a sequence of digits in one base, to any other base.
+
+Implement general base conversion. Given a number in base **a**,
+represented as a sequence of digits, convert it to base **b**.
+
+## Note
+- Try to implement the conversion yourself.
+  Do not use something else to perform the conversion for you.
+
+## About [Positional Notation](https://en.wikipedia.org/wiki/Positional_notation)
+
+In positional notation, a number in base **b** can be understood as a linear
+combination of powers of **b**.
+
+The number 42, *in base 10*, means:
+
+(4 * 10^1) + (2 * 10^0)
+
+The number 101010, *in base 2*, means:
+
+(1 * 2^5) + (0 * 2^4) + (1 * 2^3) + (0 * 2^2) + (1 * 2^1) + (0 * 2^0)
+
+The number 1120, *in base 3*, means:
+
+(1 * 3^3) + (1 * 3^2) + (2 * 3^1) + (0 * 3^0)
+
+I think you got the idea!
+
+
+*Yes. Those three numbers above are exactly the same. Congratulations!*
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/allergies/.meta/readme.go.tmpl
+++ b/exercises/allergies/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -1,0 +1,81 @@
+# Allergies
+
+Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.
+
+An allergy test produces a single numeric score which contains the
+information about all the allergies the person has (that they were
+tested for).
+
+The list of items (and their value) that were tested are:
+
+* eggs (1)
+* peanuts (2)
+* shellfish (4)
+* strawberries (8)
+* tomatoes (16)
+* chocolate (32)
+* pollen (64)
+* cats (128)
+
+So if Tom is allergic to peanuts and chocolate, he gets a score of 34.
+
+Now, given just that score of 34, your program should be able to say:
+
+- Whether Tom is allergic to any one of those allergens listed above.
+- All the allergens Tom is allergic to.
+
+Note: a given score may include allergens **not** listed above (i.e.
+allergens that score 256, 512, 1024, etc.).  Your program should
+ignore those components of the score.  For example, if the allergy
+score is 257, your program should only report the eggs (1) allergy.
+
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Jumpstart Lab Warm-up [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/anagram/.meta/readme.go.tmpl
+++ b/exercises/anagram/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -1,0 +1,57 @@
+# Anagram
+
+Given a word and a list of possible anagrams, select the correct sublist.
+
+Given `"listen"` and a list of candidates like `"enlists" "google"
+"inlets" "banana"` the program should return a list containing
+`"inlets"`.
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Inspired by the Extreme Startup game [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/atbash-cipher/.meta/readme.go.tmpl
+++ b/exercises/atbash-cipher/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -1,0 +1,78 @@
+# Atbash Cipher
+
+Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.
+
+The Atbash cipher is a simple substitution cipher that relies on
+transposing all the letters in the alphabet such that the resulting
+alphabet is backwards. The first letter is replaced with the last
+letter, the second with the second-last, and so on.
+
+An Atbash cipher for the Latin alphabet would be as follows:
+
+```plain
+Plain:  abcdefghijklmnopqrstuvwxyz
+Cipher: zyxwvutsrqponmlkjihgfedcba
+```
+
+It is a very weak cipher because it only has one possible key, and it is
+a simple monoalphabetic substitution cipher. However, this may not have
+been an issue in the cipher's time.
+
+Ciphertext is written out in groups of fixed length, the traditional group size
+being 5 letters, and punctuation is excluded. This is to make it harder to guess
+things based on word boundaries.
+
+## Examples
+- Encoding `test` gives `gvhg`
+- Decoding `gvhg` gives `test`
+- Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `thequickbrownfoxjumpsoverthelazydog`
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/Atbash](http://en.wikipedia.org/wiki/Atbash)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/bank-account/.meta/readme.go.tmpl
+++ b/exercises/bank-account/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/bank-account/README.md
+++ b/exercises/bank-account/README.md
@@ -1,0 +1,74 @@
+# Bank Account
+
+Simulate a bank account supporting opening/closing, withdrawals, and deposits
+of money. Watch out for concurrent transactions!
+
+A bank account can be accessed in multiple ways. Clients can make
+deposits and withdrawals using the internet, mobile phones, etc. Shops
+can charge against the account.
+
+Create an account that can be accessed from multiple threads/processes
+(terminology depends on your programming language).
+
+It should be possible to close an account; operations against a closed
+account must fail.
+
+## Instructions
+
+Run the test file, and fix each of the errors in turn. When you get the
+first test to pass, go to the first pending or skipped test, and make
+that pass as well. When all of the tests are passing, feel free to
+submit.
+
+Remember that passing code is just the first step. The goal is to work
+towards a solution that is as readable and expressive as you can make
+it.
+
+Have fun!
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/beer-song/.meta/readme.go.tmpl
+++ b/exercises/beer-song/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -1,0 +1,371 @@
+# Beer Song
+
+Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.
+
+Note that not all verses are identical.
+
+```plain
+99 bottles of beer on the wall, 99 bottles of beer.
+Take one down and pass it around, 98 bottles of beer on the wall.
+
+98 bottles of beer on the wall, 98 bottles of beer.
+Take one down and pass it around, 97 bottles of beer on the wall.
+
+97 bottles of beer on the wall, 97 bottles of beer.
+Take one down and pass it around, 96 bottles of beer on the wall.
+
+96 bottles of beer on the wall, 96 bottles of beer.
+Take one down and pass it around, 95 bottles of beer on the wall.
+
+95 bottles of beer on the wall, 95 bottles of beer.
+Take one down and pass it around, 94 bottles of beer on the wall.
+
+94 bottles of beer on the wall, 94 bottles of beer.
+Take one down and pass it around, 93 bottles of beer on the wall.
+
+93 bottles of beer on the wall, 93 bottles of beer.
+Take one down and pass it around, 92 bottles of beer on the wall.
+
+92 bottles of beer on the wall, 92 bottles of beer.
+Take one down and pass it around, 91 bottles of beer on the wall.
+
+91 bottles of beer on the wall, 91 bottles of beer.
+Take one down and pass it around, 90 bottles of beer on the wall.
+
+90 bottles of beer on the wall, 90 bottles of beer.
+Take one down and pass it around, 89 bottles of beer on the wall.
+
+89 bottles of beer on the wall, 89 bottles of beer.
+Take one down and pass it around, 88 bottles of beer on the wall.
+
+88 bottles of beer on the wall, 88 bottles of beer.
+Take one down and pass it around, 87 bottles of beer on the wall.
+
+87 bottles of beer on the wall, 87 bottles of beer.
+Take one down and pass it around, 86 bottles of beer on the wall.
+
+86 bottles of beer on the wall, 86 bottles of beer.
+Take one down and pass it around, 85 bottles of beer on the wall.
+
+85 bottles of beer on the wall, 85 bottles of beer.
+Take one down and pass it around, 84 bottles of beer on the wall.
+
+84 bottles of beer on the wall, 84 bottles of beer.
+Take one down and pass it around, 83 bottles of beer on the wall.
+
+83 bottles of beer on the wall, 83 bottles of beer.
+Take one down and pass it around, 82 bottles of beer on the wall.
+
+82 bottles of beer on the wall, 82 bottles of beer.
+Take one down and pass it around, 81 bottles of beer on the wall.
+
+81 bottles of beer on the wall, 81 bottles of beer.
+Take one down and pass it around, 80 bottles of beer on the wall.
+
+80 bottles of beer on the wall, 80 bottles of beer.
+Take one down and pass it around, 79 bottles of beer on the wall.
+
+79 bottles of beer on the wall, 79 bottles of beer.
+Take one down and pass it around, 78 bottles of beer on the wall.
+
+78 bottles of beer on the wall, 78 bottles of beer.
+Take one down and pass it around, 77 bottles of beer on the wall.
+
+77 bottles of beer on the wall, 77 bottles of beer.
+Take one down and pass it around, 76 bottles of beer on the wall.
+
+76 bottles of beer on the wall, 76 bottles of beer.
+Take one down and pass it around, 75 bottles of beer on the wall.
+
+75 bottles of beer on the wall, 75 bottles of beer.
+Take one down and pass it around, 74 bottles of beer on the wall.
+
+74 bottles of beer on the wall, 74 bottles of beer.
+Take one down and pass it around, 73 bottles of beer on the wall.
+
+73 bottles of beer on the wall, 73 bottles of beer.
+Take one down and pass it around, 72 bottles of beer on the wall.
+
+72 bottles of beer on the wall, 72 bottles of beer.
+Take one down and pass it around, 71 bottles of beer on the wall.
+
+71 bottles of beer on the wall, 71 bottles of beer.
+Take one down and pass it around, 70 bottles of beer on the wall.
+
+70 bottles of beer on the wall, 70 bottles of beer.
+Take one down and pass it around, 69 bottles of beer on the wall.
+
+69 bottles of beer on the wall, 69 bottles of beer.
+Take one down and pass it around, 68 bottles of beer on the wall.
+
+68 bottles of beer on the wall, 68 bottles of beer.
+Take one down and pass it around, 67 bottles of beer on the wall.
+
+67 bottles of beer on the wall, 67 bottles of beer.
+Take one down and pass it around, 66 bottles of beer on the wall.
+
+66 bottles of beer on the wall, 66 bottles of beer.
+Take one down and pass it around, 65 bottles of beer on the wall.
+
+65 bottles of beer on the wall, 65 bottles of beer.
+Take one down and pass it around, 64 bottles of beer on the wall.
+
+64 bottles of beer on the wall, 64 bottles of beer.
+Take one down and pass it around, 63 bottles of beer on the wall.
+
+63 bottles of beer on the wall, 63 bottles of beer.
+Take one down and pass it around, 62 bottles of beer on the wall.
+
+62 bottles of beer on the wall, 62 bottles of beer.
+Take one down and pass it around, 61 bottles of beer on the wall.
+
+61 bottles of beer on the wall, 61 bottles of beer.
+Take one down and pass it around, 60 bottles of beer on the wall.
+
+60 bottles of beer on the wall, 60 bottles of beer.
+Take one down and pass it around, 59 bottles of beer on the wall.
+
+59 bottles of beer on the wall, 59 bottles of beer.
+Take one down and pass it around, 58 bottles of beer on the wall.
+
+58 bottles of beer on the wall, 58 bottles of beer.
+Take one down and pass it around, 57 bottles of beer on the wall.
+
+57 bottles of beer on the wall, 57 bottles of beer.
+Take one down and pass it around, 56 bottles of beer on the wall.
+
+56 bottles of beer on the wall, 56 bottles of beer.
+Take one down and pass it around, 55 bottles of beer on the wall.
+
+55 bottles of beer on the wall, 55 bottles of beer.
+Take one down and pass it around, 54 bottles of beer on the wall.
+
+54 bottles of beer on the wall, 54 bottles of beer.
+Take one down and pass it around, 53 bottles of beer on the wall.
+
+53 bottles of beer on the wall, 53 bottles of beer.
+Take one down and pass it around, 52 bottles of beer on the wall.
+
+52 bottles of beer on the wall, 52 bottles of beer.
+Take one down and pass it around, 51 bottles of beer on the wall.
+
+51 bottles of beer on the wall, 51 bottles of beer.
+Take one down and pass it around, 50 bottles of beer on the wall.
+
+50 bottles of beer on the wall, 50 bottles of beer.
+Take one down and pass it around, 49 bottles of beer on the wall.
+
+49 bottles of beer on the wall, 49 bottles of beer.
+Take one down and pass it around, 48 bottles of beer on the wall.
+
+48 bottles of beer on the wall, 48 bottles of beer.
+Take one down and pass it around, 47 bottles of beer on the wall.
+
+47 bottles of beer on the wall, 47 bottles of beer.
+Take one down and pass it around, 46 bottles of beer on the wall.
+
+46 bottles of beer on the wall, 46 bottles of beer.
+Take one down and pass it around, 45 bottles of beer on the wall.
+
+45 bottles of beer on the wall, 45 bottles of beer.
+Take one down and pass it around, 44 bottles of beer on the wall.
+
+44 bottles of beer on the wall, 44 bottles of beer.
+Take one down and pass it around, 43 bottles of beer on the wall.
+
+43 bottles of beer on the wall, 43 bottles of beer.
+Take one down and pass it around, 42 bottles of beer on the wall.
+
+42 bottles of beer on the wall, 42 bottles of beer.
+Take one down and pass it around, 41 bottles of beer on the wall.
+
+41 bottles of beer on the wall, 41 bottles of beer.
+Take one down and pass it around, 40 bottles of beer on the wall.
+
+40 bottles of beer on the wall, 40 bottles of beer.
+Take one down and pass it around, 39 bottles of beer on the wall.
+
+39 bottles of beer on the wall, 39 bottles of beer.
+Take one down and pass it around, 38 bottles of beer on the wall.
+
+38 bottles of beer on the wall, 38 bottles of beer.
+Take one down and pass it around, 37 bottles of beer on the wall.
+
+37 bottles of beer on the wall, 37 bottles of beer.
+Take one down and pass it around, 36 bottles of beer on the wall.
+
+36 bottles of beer on the wall, 36 bottles of beer.
+Take one down and pass it around, 35 bottles of beer on the wall.
+
+35 bottles of beer on the wall, 35 bottles of beer.
+Take one down and pass it around, 34 bottles of beer on the wall.
+
+34 bottles of beer on the wall, 34 bottles of beer.
+Take one down and pass it around, 33 bottles of beer on the wall.
+
+33 bottles of beer on the wall, 33 bottles of beer.
+Take one down and pass it around, 32 bottles of beer on the wall.
+
+32 bottles of beer on the wall, 32 bottles of beer.
+Take one down and pass it around, 31 bottles of beer on the wall.
+
+31 bottles of beer on the wall, 31 bottles of beer.
+Take one down and pass it around, 30 bottles of beer on the wall.
+
+30 bottles of beer on the wall, 30 bottles of beer.
+Take one down and pass it around, 29 bottles of beer on the wall.
+
+29 bottles of beer on the wall, 29 bottles of beer.
+Take one down and pass it around, 28 bottles of beer on the wall.
+
+28 bottles of beer on the wall, 28 bottles of beer.
+Take one down and pass it around, 27 bottles of beer on the wall.
+
+27 bottles of beer on the wall, 27 bottles of beer.
+Take one down and pass it around, 26 bottles of beer on the wall.
+
+26 bottles of beer on the wall, 26 bottles of beer.
+Take one down and pass it around, 25 bottles of beer on the wall.
+
+25 bottles of beer on the wall, 25 bottles of beer.
+Take one down and pass it around, 24 bottles of beer on the wall.
+
+24 bottles of beer on the wall, 24 bottles of beer.
+Take one down and pass it around, 23 bottles of beer on the wall.
+
+23 bottles of beer on the wall, 23 bottles of beer.
+Take one down and pass it around, 22 bottles of beer on the wall.
+
+22 bottles of beer on the wall, 22 bottles of beer.
+Take one down and pass it around, 21 bottles of beer on the wall.
+
+21 bottles of beer on the wall, 21 bottles of beer.
+Take one down and pass it around, 20 bottles of beer on the wall.
+
+20 bottles of beer on the wall, 20 bottles of beer.
+Take one down and pass it around, 19 bottles of beer on the wall.
+
+19 bottles of beer on the wall, 19 bottles of beer.
+Take one down and pass it around, 18 bottles of beer on the wall.
+
+18 bottles of beer on the wall, 18 bottles of beer.
+Take one down and pass it around, 17 bottles of beer on the wall.
+
+17 bottles of beer on the wall, 17 bottles of beer.
+Take one down and pass it around, 16 bottles of beer on the wall.
+
+16 bottles of beer on the wall, 16 bottles of beer.
+Take one down and pass it around, 15 bottles of beer on the wall.
+
+15 bottles of beer on the wall, 15 bottles of beer.
+Take one down and pass it around, 14 bottles of beer on the wall.
+
+14 bottles of beer on the wall, 14 bottles of beer.
+Take one down and pass it around, 13 bottles of beer on the wall.
+
+13 bottles of beer on the wall, 13 bottles of beer.
+Take one down and pass it around, 12 bottles of beer on the wall.
+
+12 bottles of beer on the wall, 12 bottles of beer.
+Take one down and pass it around, 11 bottles of beer on the wall.
+
+11 bottles of beer on the wall, 11 bottles of beer.
+Take one down and pass it around, 10 bottles of beer on the wall.
+
+10 bottles of beer on the wall, 10 bottles of beer.
+Take one down and pass it around, 9 bottles of beer on the wall.
+
+9 bottles of beer on the wall, 9 bottles of beer.
+Take one down and pass it around, 8 bottles of beer on the wall.
+
+8 bottles of beer on the wall, 8 bottles of beer.
+Take one down and pass it around, 7 bottles of beer on the wall.
+
+7 bottles of beer on the wall, 7 bottles of beer.
+Take one down and pass it around, 6 bottles of beer on the wall.
+
+6 bottles of beer on the wall, 6 bottles of beer.
+Take one down and pass it around, 5 bottles of beer on the wall.
+
+5 bottles of beer on the wall, 5 bottles of beer.
+Take one down and pass it around, 4 bottles of beer on the wall.
+
+4 bottles of beer on the wall, 4 bottles of beer.
+Take one down and pass it around, 3 bottles of beer on the wall.
+
+3 bottles of beer on the wall, 3 bottles of beer.
+Take one down and pass it around, 2 bottles of beer on the wall.
+
+2 bottles of beer on the wall, 2 bottles of beer.
+Take one down and pass it around, 1 bottle of beer on the wall.
+
+1 bottle of beer on the wall, 1 bottle of beer.
+Take it down and pass it around, no more bottles of beer on the wall.
+
+No more bottles of beer on the wall, no more bottles of beer.
+Go to the store and buy some more, 99 bottles of beer on the wall.
+```
+
+## For bonus points
+
+Did you get the tests passing and the code clean? If you want to, these
+are some additional things you could try:
+
+* Remove as much duplication as you possibly can.
+* Optimize for readability, even if it means introducing duplication.
+* If you've removed all the duplication, do you have a lot of
+  conditionals? Try replacing the conditionals with polymorphism, if it
+  applies in this language. How readable is it?
+
+Then please share your thoughts in a comment on the submission. Did this
+experiment make the code better? Worse? Did you learn anything from it?
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Learn to Program by Chris Pine [http://pine.fm/LearnToProgram/?Chapter=06](http://pine.fm/LearnToProgram/?Chapter=06)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/bob/.meta/readme.go.tmpl
+++ b/exercises/bob/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -1,0 +1,62 @@
+# Bob
+
+Bob is a lackadaisical teenager. In conversation, his responses are very limited.
+
+Bob answers 'Sure.' if you ask him a question.
+
+He answers 'Whoa, chill out!' if you yell at him.
+
+He says 'Fine. Be that way!' if you address him without actually saying
+anything.
+
+He answers 'Whatever.' to anything else.
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=06](http://pine.fm/LearnToProgram/?Chapter=06)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/circular-buffer/.meta/readme.go.tmpl
+++ b/exercises/circular-buffer/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/circular-buffer/README.md
+++ b/exercises/circular-buffer/README.md
@@ -1,0 +1,94 @@
+# Circular Buffer
+
+A circular buffer, cyclic buffer or ring buffer is a data structure that
+uses a single, fixed-size buffer as if it were connected end-to-end.
+
+A circular buffer first starts empty and of some predefined length. For
+example, this is a 7-element buffer:
+
+    [ ][ ][ ][ ][ ][ ][ ]
+
+Assume that a 1 is written into the middle of the buffer (exact starting
+location does not matter in a circular buffer):
+
+    [ ][ ][ ][1][ ][ ][ ]
+
+Then assume that two more elements are added — 2 & 3 — which get
+appended after the 1:
+
+    [ ][ ][ ][1][2][3][ ]
+
+If two elements are then removed from the buffer, the oldest values
+inside the buffer are removed. The two elements removed, in this case,
+are 1 & 2, leaving the buffer with just a 3:
+
+    [ ][ ][ ][ ][ ][3][ ]
+
+If the buffer has 7 elements then it is completely full:
+
+    [6][7][8][9][3][4][5]
+
+When the buffer is full an error will be raised, alerting the client
+that further writes are blocked until a slot becomes free.
+
+The client can opt to overwrite the oldest data with a forced write. In
+this case, two more elements — A & B — are added and they overwrite the
+3 & 4:
+
+    [6][7][8][9][A][B][5]
+
+Finally, if two elements are now removed then what would be returned is
+not 3 & 4 but 5 & 6 because A & B overwrote the 3 & the 4 yielding the
+buffer with:
+
+    [ ][7][8][9][A][B][ ]
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/Circular_buffer](http://en.wikipedia.org/wiki/Circular_buffer)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/clock/.meta/readme.go.tmpl
+++ b/exercises/clock/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -1,0 +1,57 @@
+# Clock
+
+Implement a clock that handles times without dates.
+
+You should be able to add and subtract minutes to it.
+
+Two clocks that represent the same time should be equal to each other.
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Pairing session with Erin Drummond [https://twitter.com/ebdrummond](https://twitter.com/ebdrummond)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/collatz-conjecture/.meta/readme.go.tmpl
+++ b/exercises/collatz-conjecture/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -1,0 +1,77 @@
+# Collatz Conjecture
+
+The Collatz Conjecture or 3x+1 problem can be summarized as follows:
+
+Take any positive integer n. If n is even, divide n by 2 to get n / 2. If n is
+odd, multiply n by 3 and add 1 to get 3n + 1. Repeat the process indefinitely.
+The conjecture states that no matter which number you start with, you will
+always reach 1 eventually.
+
+Given a number n, return the number of steps required to reach 1.
+
+## Examples
+Starting with n = 12, the steps would be as follows:
+
+0. 12
+1. 6
+2. 3
+3. 10
+4. 5
+5. 16
+6. 8
+7. 4
+8. 2
+9. 1
+
+Resulting in 9 steps. So for input n = 12, the return value would be 9.
+
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+An unsolved problem in mathematics named after mathematician Lothar Collatz [https://en.wikipedia.org/wiki/3x_%2B_1_problem](https://en.wikipedia.org/wiki/3x_%2B_1_problem)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/difference-of-squares/.meta/readme.go.tmpl
+++ b/exercises/difference-of-squares/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -1,0 +1,63 @@
+# Difference Of Squares
+
+Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.
+
+The square of the sum of the first ten natural numbers is
+(1 + 2 + ... + 10)² = 55² = 3025.
+
+The sum of the squares of the first ten natural numbers is
+1² + 2² + ... + 10² = 385.
+
+Hence the difference between the square of the sum of the first
+ten natural numbers and the sum of the squares of the first ten
+natural numbers is 3025 - 385 = 2640.
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Problem 6 at Project Euler [http://projecteuler.net/problem=6](http://projecteuler.net/problem=6)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/etl/.meta/readme.go.tmpl
+++ b/exercises/etl/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -1,0 +1,95 @@
+# Etl
+
+We are going to do the `Transform` step of an Extract-Transform-Load.
+
+### ETL
+Extract-Transform-Load (ETL) is a fancy way of saying, "We have some crufty, legacy data over in this system, and now we need it in this shiny new system over here, so
+we're going to migrate this."
+
+(Typically, this is followed by, "We're only going to need to run this
+once." That's then typically followed by much forehead slapping and
+moaning about how stupid we could possibly be.)
+
+### The goal
+We're going to extract some scrabble scores from a legacy system.
+
+The old system stored a list of letters per score:
+
+- 1 point: "A", "E", "I", "O", "U", "L", "N", "R", "S", "T",
+- 2 points: "D", "G",
+- 3 points: "B", "C", "M", "P",
+- 4 points: "F", "H", "V", "W", "Y",
+- 5 points: "K",
+- 8 points: "J", "X",
+- 10 points: "Q", "Z",
+
+The shiny new scrabble system instead stores the score per letter, which
+makes it much faster and easier to calculate the score for a word. It
+also stores the letters in lower-case regardless of the case of the
+input letters:
+
+- "a" is worth 1 point.
+- "b" is worth 3 points.
+- "c" is worth 3 points.
+- "d" is worth 2 points.
+- Etc.
+
+Your mission, should you choose to accept it, is to transform the legacy data
+format to the shiny new format.
+
+### Notes
+
+A final note about scoring, Scrabble is played around the world in a
+variety of languages, each with its own unique scoring table. For
+example, an "E" is scored at 2 in the Māori-language version of the
+game while being scored at 4 in the Hawaiian-language version.
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+The Jumpstart Lab team [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/gigasecond/.meta/readme.go.tmpl
+++ b/exercises/gigasecond/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -1,0 +1,55 @@
+# Gigasecond
+
+Calculate the moment when someone has lived for 10^9 seconds.
+
+A gigasecond is 10^9 (1,000,000,000) seconds.
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Chapter 9 in Chris Pine's online Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=09](http://pine.fm/LearnToProgram/?Chapter=09)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/grade-school/.meta/readme.go.tmpl
+++ b/exercises/grade-school/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -1,0 +1,86 @@
+# Grade School
+
+Given students' names along with the grade that they are in, create a roster
+for the school.
+
+In the end, you should be able to:
+
+- Add a student's name to the roster for a grade
+  - "Add Jim to grade 2."
+  - "OK."
+- Get a list of all students enrolled in a grade
+  - "Which students are in grade 2?"
+  - "We've only got Jim just now."
+- Get a sorted list of all students in all grades.  Grades should sort
+  as 1, 2, 3, etc., and students within a grade should be sorted
+  alphabetically by name.
+  - "Who all is enrolled in school right now?"
+  - "Grade 1: Anna, Barb, and Charlie. Grade 2: Alex, Peter, and Zoe.
+    Grade 3…"
+
+Note that all our students only have one name.  (It's a small town, what
+do you want?)
+
+
+## For bonus points
+
+Did you get the tests passing and the code clean? If you want to, these
+are some additional things you could try:
+
+- If you're working in a language with mutable data structures and your
+  implementation allows outside code to mutate the school's internal DB
+  directly, see if you can prevent this. Feel free to introduce additional
+  tests.
+
+Then please share your thoughts in a comment on the submission. Did this
+experiment make the code better? Worse? Did you learn anything from it?
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+A pairing session with Phil Battos at gSchool [http://gschool.it](http://gschool.it)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/grains/.meta/readme.go.tmpl
+++ b/exercises/grains/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -1,0 +1,78 @@
+# Grains
+
+Calculate the number of grains of wheat on a chessboard given that the number
+on each square doubles.
+
+There once was a wise servant who saved the life of a prince. The king
+promised to pay whatever the servant could dream up. Knowing that the
+king loved chess, the servant told the king he would like to have grains
+of wheat. One grain on the first square of a chess board. Two grains on
+the next. Four on the third, and so on.
+
+There are 64 squares on a chessboard.
+
+Write code that shows:
+- how many grains were on each square, and
+- the total number of grains
+
+
+## For bonus points
+
+Did you get the tests passing and the code clean? If you want to, these
+are some additional things you could try:
+
+- Optimize for speed.
+- Optimize for readability.
+
+Then please share your thoughts in a comment on the submission. Did this
+experiment make the code better? Worse? Did you learn anything from it?
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+JavaRanch Cattle Drive, exercise 6 [http://www.javaranch.com/grains.jsp](http://www.javaranch.com/grains.jsp)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/hamming/.meta/readme.go.tmpl
+++ b/exercises/hamming/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -1,0 +1,86 @@
+# Hamming
+
+Calculate the Hamming difference between two DNA strands.
+
+A mutation is simply a mistake that occurs during the creation or
+copying of a nucleic acid, in particular DNA. Because nucleic acids are
+vital to cellular functions, mutations tend to cause a ripple effect
+throughout the cell. Although mutations are technically mistakes, a very
+rare mutation may equip the cell with a beneficial attribute. In fact,
+the macro effects of evolution are attributable by the accumulated
+result of beneficial microscopic mutations over many generations.
+
+The simplest and most common type of nucleic acid mutation is a point
+mutation, which replaces one base with another at a single nucleotide.
+
+By counting the number of differences between two homologous DNA strands
+taken from different genomes with a common ancestor, we get a measure of
+the minimum number of point mutations that could have occurred on the
+evolutionary path between the two strands.
+
+This is called the 'Hamming distance'.
+
+It is found by comparing two DNA strands and counting how many of the
+nucleotides are different from their equivalent in the other string.
+
+    GAGCCTACTAACGGGAT
+    CATCGTAATGACGGCCT
+    ^ ^ ^  ^ ^    ^^
+
+The Hamming distance between these two DNA strands is 7.
+
+# Implementation notes
+
+The Hamming distance is only defined for sequences of equal length. This means
+that based on the definition, each language could deal with getting sequences
+of equal length differently.
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+The Calculating Point Mutations problem at Rosalind [http://rosalind.info/problems/hamm/](http://rosalind.info/problems/hamm/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/hello-world/.meta/readme.go.tmpl
+++ b/exercises/hello-world/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -1,0 +1,65 @@
+# Hello World
+
+The classical introductory exercise. Just say "Hello, World!".
+
+["Hello, World!"](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program) is
+the traditional first program for beginning programming in a new language
+or environment.
+
+The objectives are simple:
+
+- Write a function that returns the string "Hello, World!".
+- Run the test suite and make sure that it succeeds.
+- Submit your solution and check it at the website.
+
+If everything goes well, you will be ready to fetch your first real exercise.
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+This is an exercise to introduce users to using Exercism [http://en.wikipedia.org/wiki/%22Hello,_world!%22_program](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/largest-series-product/.meta/readme.go.tmpl
+++ b/exercises/largest-series-product/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -1,0 +1,64 @@
+# Largest Series Product
+
+Given a string of digits, calculate the largest product for a contiguous
+substring of digits of length n.
+
+For example, for the input `'1027839564'`, the largest product for a
+series of 3 digits is 270 (9 * 5 * 6), and the largest product for a
+series of 5 digits is 7560 (7 * 8 * 3 * 9 * 5).
+
+Note that these series are only required to occupy *adjacent positions*
+in the input; the digits need not be *numerically consecutive*.
+
+For the input `'73167176531330624919225119674426574742355349194934'`,
+the largest product for a series of 6 digits is 23520.
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+A variation on Problem 8 at Project Euler [http://projecteuler.net/problem=8](http://projecteuler.net/problem=8)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/leap/.meta/readme.go.tmpl
+++ b/exercises/leap/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -1,0 +1,77 @@
+# Leap
+
+Given a year, report if it is a leap year.
+
+The tricky thing here is that a leap year in the Gregorian calendar occurs:
+
+```plain
+on every year that is evenly divisible by 4
+  except every year that is evenly divisible by 100
+    unless the year is also evenly divisible by 400
+```
+
+For example, 1997 is not a leap year, but 1996 is.  1900 is not a leap
+year, but 2000 is.
+
+If your language provides a method in the standard library that does
+this look-up, pretend it doesn't exist and implement it yourself.
+
+## Notes
+
+Though our exercise adopts some very simple rules, there is more to
+learn!
+
+For a delightful, four minute explanation of the whole leap year
+phenomenon, go watch [this youtube video][video].
+
+[video]: http://www.youtube.com/watch?v=xX96xng7sAE
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+JavaRanch Cattle Drive, exercise 3 [http://www.javaranch.com/leap.jsp](http://www.javaranch.com/leap.jsp)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/luhn/.meta/readme.go.tmpl
+++ b/exercises/luhn/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -1,0 +1,115 @@
+# Luhn
+
+Given a number determine whether or not it is valid per the Luhn formula.
+
+The [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm) is
+a simple checksum formula used to validate a variety of identification
+numbers, such as credit card numbers and Canadian Social Insurance
+Numbers.
+
+The task is to check if a given string is valid.
+
+Validating a Number
+------
+
+Strings of length 1 or less are not valid. Spaces are allowed in the input,
+but they should be stripped before checking. All other non-digit characters
+are disallowed.
+
+## Example 1: valid credit card number
+
+```
+4539 1488 0343 6467
+```
+
+The first step of the Luhn algorithm is to double every second digit,
+starting from the right. We will be doubling
+
+```
+4_3_ 1_8_ 0_4_ 6_6_
+```
+
+If doubling the number results in a number greater than 9 then subtract 9
+from the product. The results of our doubling:
+
+```
+8569 2478 0383 3437
+```
+
+Then sum all of the digits:
+
+```
+8+5+6+9+2+4+7+8+0+3+8+3+3+4+3+7 = 80
+```
+
+If the sum is evenly divisible by 10, then the number is valid. This number is valid!
+
+## Example 2: invalid credit card number
+
+```
+8273 1232 7352 0569
+```
+
+Double the second digits, starting from the right
+
+```
+7253 2262 5312 0539
+```
+
+Sum the digits
+
+```
+7+2+5+3+2+2+6+2+5+3+1+2+0+5+3+9 = 57
+```
+
+57 is not evenly divisible by 10, so this number is not valid.
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+The Luhn Algorithm on Wikipedia [http://en.wikipedia.org/wiki/Luhn_algorithm](http://en.wikipedia.org/wiki/Luhn_algorithm)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/meetup/.meta/readme.go.tmpl
+++ b/exercises/meetup/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -1,0 +1,74 @@
+# Meetup
+
+Calculate the date of meetups.
+
+Typically meetups happen on the same day of the week.  In this exercise, you will take
+a description of a meetup date, and return the actual meetup date.
+
+Examples of general descriptions are:
+
+- the first Monday of January 2017
+- the third Tuesday of January 2017
+- the Wednesteenth of January 2017
+- the last Thursday of January 2017
+
+Note that "Monteenth", "Tuesteenth", etc are all made up words. There
+was a meetup whose members realized that there are exactly 7 numbered days in a month that
+end in '-teenth'. Therefore, one is guaranteed that each day of the week
+(Monday, Tuesday, ...) will have exactly one date that is named with '-teenth'
+in every month.
+
+Given examples of a meetup dates, each containing a month, day, year, and descriptor 
+(first, second, teenth, etc), calculate the date of the actual meetup.
+For example, if given "First Monday of January 2017", the correct meetup date is 2017/1/2
+ 
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month [https://twitter.com/copiousfreetime](https://twitter.com/copiousfreetime)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/nucleotide-count/.meta/readme.go.tmpl
+++ b/exercises/nucleotide-count/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -1,0 +1,77 @@
+# Nucleotide Count
+
+Given a DNA string, compute how many times each nucleotide occurs in the string.
+
+DNA is represented by an alphabet of the following symbols: 'A', 'C',
+'G', and 'T'.
+
+Each symbol represents a nucleotide, which is a fancy name for the
+particular molecules that happen to make up a large part of DNA.
+
+Shortest intro to biochemistry EVAR:
+
+- twigs are to birds nests as
+- nucleotides are to DNA and RNA as
+- amino acids are to proteins as
+- sugar is to starch as
+- oh crap lipids
+
+I'm not going to talk about lipids because they're crazy complex.
+
+So back to nucleotides.
+
+DNA contains four types of them: adenine (`A`), cytosine (`C`), guanine
+(`G`), and thymine (`T`).
+
+RNA contains a slightly different set of nucleotides, but we don't care
+about that for now.
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+The Calculating DNA Nucleotides_problem at Rosalind [http://rosalind.info/problems/dna/](http://rosalind.info/problems/dna/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/parallel-letter-frequency/.meta/readme.go.tmpl
+++ b/exercises/parallel-letter-frequency/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/parallel-letter-frequency/README.md
+++ b/exercises/parallel-letter-frequency/README.md
@@ -1,0 +1,55 @@
+# Parallel Letter Frequency
+
+Count the frequency of letters in texts using parallel computation.
+
+Parallelism is about doing things in parallel that can also be done
+sequentially. A common example is counting the frequency of letters.
+Create a function that returns the total frequency of each letter in a
+list of texts and that employs parallelism.
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/phone-number/.meta/readme.go.tmpl
+++ b/exercises/phone-number/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -1,0 +1,78 @@
+# Phone Number
+
+Clean up user-entered phone numbers so that they can be sent SMS messages.
+
+The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda. All NANP-countries share the same international country code: `1`.
+
+NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as *area code*, followed by a seven-digit local number. The first three digits of the local number represent the *exchange code*, followed by the unique four-digit number which is the *subscriber number*.
+
+
+The format is usually represented as
+```
+(NXX)-NXX-XXXX
+```
+where `N` is any digit from 2 through 9 and `X` is any digit from 0 through 9.
+
+Your task is to clean up differently formated telephone numbers by removing punctuation and the country code (1) if present.
+
+For example, the inputs
+- `+1 (613)-995-0253`
+- `613-995-0253`
+- `1 613 995 0253`
+- `613.995.0253`
+
+should all produce the output
+
+`6139950253`
+
+**Note:** As this exercise only deals with telephone numbers used in NANP-countries, only 1 is considered a valid country code.
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Event Manager by JumpstartLab [http://tutorials.jumpstartlab.com/projects/eventmanager.html](http://tutorials.jumpstartlab.com/projects/eventmanager.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/rna-transcription/.meta/readme.go.tmpl
+++ b/exercises/rna-transcription/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -1,0 +1,69 @@
+# Rna Transcription
+
+Given a DNA strand, return its RNA complement (per RNA transcription).
+
+Both DNA and RNA strands are a sequence of nucleotides.
+
+The four nucleotides found in DNA are adenine (**A**), cytosine (**C**),
+guanine (**G**) and thymine (**T**).
+
+The four nucleotides found in RNA are adenine (**A**), cytosine (**C**),
+guanine (**G**) and uracil (**U**).
+
+Given a DNA strand, its transcribed RNA strand is formed by replacing
+each nucleotide with its complement:
+
+* `G` -> `C`
+* `C` -> `G`
+* `T` -> `A`
+* `A` -> `U`
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Rosalind [http://rosalind.info/problems/rna](http://rosalind.info/problems/rna)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/robot-simulator/.meta/readme.go.tmpl
+++ b/exercises/robot-simulator/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/robot-simulator/README.md
+++ b/exercises/robot-simulator/README.md
@@ -1,0 +1,89 @@
+# Robot Simulator
+
+Write a robot simulator.
+
+A robot factory's test facility needs a program to verify robot movements.
+
+The robots have three possible movements:
+
+- turn right
+- turn left
+- advance
+
+Robots are placed on a hypothetical infinite grid, facing a particular
+direction (north, east, south, or west) at a set of {x,y} coordinates,
+e.g., {3,8}, with coordinates increasing to the north and east.
+
+The robot then receives a number of instructions, at which point the
+testing facility verifies the robot's new position, and in which
+direction it is pointing.
+
+- The letter-string "RAALAL" means:
+  - Turn right
+  - Advance twice
+  - Turn left
+  - Advance once
+  - Turn left yet again
+- Say a robot starts at {7, 3} facing north. Then running this stream
+  of instructions should leave it at {9, 4} facing west.
+
+This exercise does require some kind of global state for your
+robot. In erlang this can be done in various ways (starting with most
+idiomatic one):
+
+1. Use some `gen_*` from OTP
+2. Roll your own process and receive messages in a loop and pass the
+   state as parameter around.
+3. Roll your own process and use the process dictionary.
+
+
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Inspired by an interview question at a famous company.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/roman-numerals/.meta/readme.go.tmpl
+++ b/exercises/roman-numerals/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -1,0 +1,93 @@
+# Roman Numerals
+
+Write a function to convert from normal numbers to Roman Numerals.
+
+The Romans were a clever bunch. They conquered most of Europe and ruled
+it for hundreds of years. They invented concrete and straight roads and
+even bikinis. One thing they never discovered though was the number
+zero. This made writing and dating extensive histories of their exploits
+slightly more challenging, but the system of numbers they came up with
+is still in use today. For example the BBC uses Roman numerals to date
+their programmes.
+
+The Romans wrote numbers using letters - I, V, X, L, C, D, M. (notice
+these letters have lots of straight lines and are hence easy to hack
+into stone tablets).
+
+```
+ 1  => I
+10  => X
+ 7  => VII
+```
+
+There is no need to be able to convert numbers larger than about 3000.
+(The Romans themselves didn't tend to go any higher)
+
+Wikipedia says: Modern Roman numerals ... are written by expressing each
+digit separately starting with the left most digit and skipping any
+digit with a value of zero.
+
+To see this in practice, consider the example of 1990.
+
+In Roman numerals 1990 is MCMXC:
+
+1000=M
+900=CM
+90=XC
+
+2008 is written as MMVIII:
+
+2000=MM
+8=VIII
+
+See also: http://www.novaroma.org/via_romana/numbers.html
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+The Roman Numeral Kata [http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals](http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/rotational-cipher/.meta/readme.go.tmpl
+++ b/exercises/rotational-cipher/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -1,0 +1,80 @@
+# Rotational Cipher
+
+Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.
+
+The Caesar cipher is a simple shift cipher that relies on
+transposing all the letters in the alphabet using an integer key
+between `0` and `26`. Using a key of `0` or `26` will always yield
+the same output due to modular arithmetic. The letter is shifted
+for as many values as the value of the key.
+
+The general notation for rotational ciphers is `ROT + <key>`.
+The most commonly used rotational cipher is `ROT13`.
+
+A `ROT13` on the Latin alphabet would be as follows:
+
+```plain
+Plain:  abcdefghijklmnopqrstuvwxyz
+Cipher: nopqrstuvwxyzabcdefghijklm
+```
+
+It is stronger than the Atbash cipher because it has 27 possible keys, and 25 usable keys.
+
+Ciphertext is written out in the same formatting as the input including spaces and punctuation.
+
+## Examples
+- ROT5  `omg` gives `trl`
+- ROT0  `c` gives `c`
+- ROT26 `Cool` gives `Cool`
+- ROT13 `The quick brown fox jumps over the lazy dog.` gives `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.`
+- ROT13 `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.` gives `The quick brown fox jumps over the lazy dog.`
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Caesar_cipher](https://en.wikipedia.org/wiki/Caesar_cipher)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/scrabble-score/.meta/readme.go.tmpl
+++ b/exercises/scrabble-score/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -1,0 +1,88 @@
+# Scrabble Score
+
+Given a word, compute the scrabble score for that word.
+
+## Letter Values
+
+You'll need these:
+
+```plain
+Letter                           Value
+A, E, I, O, U, L, N, R, S, T       1
+D, G                               2
+B, C, M, P                         3
+F, H, V, W, Y                      4
+K                                  5
+J, X                               8
+Q, Z                               10
+```
+
+## Examples
+"cabbage" should be scored as worth 14 points:
+
+- 3 points for C
+- 1 point for A, twice
+- 3 points for B, twice
+- 2 points for G
+- 1 point for E
+
+And to total:
+
+- `3 + 2*1 + 2*3 + 2 + 1`
+- = `3 + 2 + 6 + 3`
+- = `5 + 9`
+- = 14
+
+## Extensions
+- You can play a double or a triple letter.
+- You can play a double or a triple word.
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Inspired by the Extreme Startup game [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/series/.meta/readme.go.tmpl
+++ b/exercises/series/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -1,0 +1,71 @@
+# Series
+
+Given a string of digits, output all the contiguous substrings of length `n` in
+that string.
+
+For example, the string "49142" has the following 3-digit series:
+
+- 491
+- 914
+- 142
+
+And the following 4-digit series:
+
+- 4914
+- 9142
+
+And if you ask for a 6-digit series from a 5-digit string, you deserve
+whatever you get.
+
+Note that these series are only required to occupy *adjacent positions*
+in the input; the digits need not be *numerically consecutive*.
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+A subset of the Problem 8 at Project Euler [http://projecteuler.net/problem=8](http://projecteuler.net/problem=8)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/space-age/.meta/readme.go.tmpl
+++ b/exercises/space-age/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -1,0 +1,68 @@
+# Space Age
+
+Given an age in seconds, calculate how old someone would be on:
+
+   - Earth: orbital period 365.25 Earth days, or 31557600 seconds
+   - Mercury: orbital period 0.2408467 Earth years
+   - Venus: orbital period 0.61519726 Earth years
+   - Mars: orbital period 1.8808158 Earth years
+   - Jupiter: orbital period 11.862615 Earth years
+   - Saturn: orbital period 29.447498 Earth years
+   - Uranus: orbital period 84.016846 Earth years
+   - Neptune: orbital period 164.79132 Earth years
+
+So if you were told someone were 1,000,000,000 seconds old, you should
+be able to say that they're 31 Earth-years old.
+
+If you're wondering why Pluto didn't make the cut, go watch [this
+youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=01](http://pine.fm/LearnToProgram/?Chapter=01)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/spiral-matrix/.meta/readme.go.tmpl
+++ b/exercises/spiral-matrix/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/spiral-matrix/README.md
+++ b/exercises/spiral-matrix/README.md
@@ -1,0 +1,74 @@
+# Spiral Matrix
+
+Given the size, return a square matrix of numbers in spiral order.
+
+The matrix should be filled with natural numbers, starting from 1
+in the top-left corner, increasing in an inward, clockwise spiral order,
+like these examples:
+
+###### Spiral matrix of size 3
+
+```plain
+1 2 3
+8 9 4
+7 6 5
+```
+
+###### Spiral matrix of size 4
+
+```plain
+ 1  2  3 4
+12 13 14 5
+11 16 15 6
+10  9  8 7
+```
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Reddit r/dailyprogrammer challenge #320 [Easy] Spiral Ascension. [https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/](https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/strain/.meta/readme.go.tmpl
+++ b/exercises/strain/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/strain/README.md
+++ b/exercises/strain/README.md
@@ -1,0 +1,84 @@
+# Strain
+
+Implement the `keep` and `discard` operation on collections. Given a collection
+and a predicate on the collection's elements, `keep` returns a new collection
+containing those elements where the predicate is true, while `discard` returns
+a new collection containing those elements where the predicate is false.
+
+For example, given the collection of numbers:
+
+- 1, 2, 3, 4, 5
+
+And the predicate:
+
+- is the number even?
+
+Then your keep operation should produce:
+
+- 2, 4
+
+While your discard operation should produce:
+
+- 1, 3, 5
+
+Note that the union of keep and discard is all the elements.
+
+The functions may be called `keep` and `discard`, or they may need different
+names in order to not clash with existing functions or concepts in your
+language.
+
+## Restrictions
+
+Keep your hands off that filter/reject/whatchamacallit functionality
+provided by your standard library!  Solve this one yourself using other
+basic tools instead.
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Conversation with James Edward Gray II [https://twitter.com/jeg2](https://twitter.com/jeg2)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/sum-of-multiples/.meta/readme.go.tmpl
+++ b/exercises/sum-of-multiples/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -1,0 +1,62 @@
+# Sum Of Multiples
+
+Given a number, find the sum of all the multiples of particular numbers up to
+but not including that number.
+
+If we list all the natural numbers up to but not including 20 that are
+multiples of either 3 or 5, we get 3, 5, 6 and 9, 10, 12, 15, and 18.
+
+The sum of these multiples is 78.
+
+Given a number, find the sum of the multiples of a given set of numbers,
+up to but not including that number.
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+A variation on Problem 1 at Project Euler [http://projecteuler.net/problem=1](http://projecteuler.net/problem=1)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/triangle/.meta/readme.go.tmpl
+++ b/exercises/triangle/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -1,0 +1,70 @@
+# Triangle
+
+Determine if a triangle is equilateral, isosceles, or scalene.
+
+An _equilateral_ triangle has all three sides the same length.<br/>
+An _isosceles_ triangle has at least two sides the same length. (It is sometimes
+specified as having exactly two sides the same length, but for the purposes of
+this exercise we'll say at least two.)<br/>
+A _scalene_ triangle has all sides of different lengths.
+
+## Note
+
+For a shape to be a triangle at all, all sides have to be of length > 0, and 
+the sum of the lengths of any two sides must be greater than or equal to the 
+length of the third side. See [Triangle Inequality](https://en.wikipedia.org/wiki/Triangle_inequality).
+
+## Dig Deeper
+
+The case where the sum of the lengths of two sides _equals_ that of the 
+third is known as a _degenerate_ triangle - it has zero area and looks like 
+a single line. Feel free to add your own code/tests to check for degenerate triangles.
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+The Ruby Koans triangle project, parts 1 & 2 [http://rubykoans.com](http://rubykoans.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/word-count/.meta/readme.go.tmpl
+++ b/exercises/word-count/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -1,0 +1,63 @@
+# Word Count
+
+Given a phrase, count the occurrences of each word in that phrase.
+
+For example for the input `"olly olly in come free"`
+
+```plain
+olly: 2
+in: 1
+come: 1
+free: 1
+```
+
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/zipper/.meta/readme.go.tmpl
+++ b/exercises/zipper/.meta/readme.go.tmpl
@@ -1,0 +1,17 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+

--- a/exercises/zipper/README.md
+++ b/exercises/zipper/README.md
@@ -1,0 +1,75 @@
+# Zipper
+
+Creating a zipper for a binary tree.
+
+[Zippers](https://en.wikipedia.org/wiki/Zipper_%28data_structure%29) are
+a way purely functional of navigating within a data structure and
+manipulating it.  They essentially contain a data structure and a
+pointer into that data structure (called the focus).
+
+For example given a rose tree (where each node contains a value and a
+list of child nodes) a zipper might support these operations:
+
+- `from_tree` (get a zipper out of a rose tree, the focus is on the root node)
+- `to_tree` (get the rose tree out of the zipper)
+- `value` (get the value of the focus node)
+- `prev` (move the focus to the previous child of the same parent,
+  returns a new zipper)
+- `next` (move the focus to the next child of the same parent, returns a
+  new zipper)
+- `up` (move the focus to the parent, returns a new zipper)
+- `set_value` (set the value of the focus node, returns a new zipper)
+- `insert_before` (insert a new subtree before the focus node, it
+  becomes the `prev` of the focus node, returns a new zipper)
+- `insert_after` (insert a new subtree after the focus node, it becomes
+  the `next` of the focus node, returns a new zipper)
+- `delete` (removes the focus node and all subtrees, focus moves to the
+  `next` node if possible otherwise to the `prev` node if possible,
+  otherwise to the parent node, returns a new zipper)
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+


### PR DESCRIPTION
We are working towards making exercises stand-alone.
That is to say: no more generating READMEs on the fly.

This will give maintainers more control over each individual exercise
README, and it will also make some of the backend logic for delivering
exercises simpler.

This does not mean, however, hand-crafting READMEs from scratch.

I wrote some tooling to make it possible to generate the READMEs from
a customizable template.

The template uses the Go text/template package, and the default template
will generate the same READMEs as we have been generating on the fly.

See the documentation in [regenerating exercise readmes][regenerate-docs] for
details.

The READMEs can be generated at any time using a new 'generate' command in configlet
(see https://github.com/exercism/configlet/pull/24). This command has not yet landed
in master or been released, but can be built from source in the generate-readmes branch
on [configlet][].

[configlet]: https://github.com/exercism/configlet
[regenerate-docs]: https://github.com/exercism/docs/blob/master/maintaining-a-track/regenerating-exercise-readmes.md