### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,278 +5,385 @@
   "active": true,
   "exercises": [
     {
+      "uuid": "50547bc4-a78e-4450-9412-30bfa46c4a93",
       "slug": "hello-world",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
       "topics": [
 
-      ],
-      "difficulty": 1
+      ]
     },
     {
+      "uuid": "241eb25c-925b-4395-876c-c1dfe84e1c85",
       "slug": "leap",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
       "topics": [
 
-      ],
-      "difficulty": 1
+      ]
     },
     {
+      "uuid": "a21065ca-6aad-46b2-ada0-6a62abfcea2b",
       "slug": "accumulate",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
       "topics": [
 
-      ],
-      "difficulty": 1
+      ]
     },
     {
+      "uuid": "63c77b77-5a02-40ce-b5f6-372a5b3ae13d",
       "slug": "collatz-conjecture",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 1,
       "topics": [
 
-      ],
-      "difficulty": 1
+      ]
     },
     {
+      "uuid": "8e9a98b1-bf4f-4c94-a258-a8618cc37f55",
       "slug": "rna-transcription",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 2,
       "topics": [
 
-      ],
-      "difficulty": 2
+      ]
     },
     {
+      "uuid": "fced3620-26f2-4439-822c-27e1d59e24e1",
       "slug": "bob",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 2,
       "topics": [
 
-      ],
-      "difficulty": 2
+      ]
     },
     {
+      "uuid": "c10bfbab-0b58-4fcb-aadc-304bd4b73cfc",
       "slug": "strain",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 2,
       "topics": [
 
-      ],
-      "difficulty": 2
+      ]
     },
     {
+      "uuid": "8b7390fc-da44-4f02-ad17-a7eb5c19cf2b",
       "slug": "hamming",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 2,
       "topics": [
 
-      ],
-      "difficulty": 2
+      ]
     },
     {
+      "uuid": "f276e064-a6d4-4a50-b53b-f36c1b30c62f",
       "slug": "space-age",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 2,
       "topics": [
 
-      ],
-      "difficulty": 2
+      ]
     },
     {
+      "uuid": "c3070adc-d434-4989-8d6b-d9e483e32d1c",
       "slug": "grains",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 2,
       "topics": [
 
-      ],
-      "difficulty": 2
+      ]
     },
     {
+      "uuid": "d3cbfc9a-a495-4bf2-87d0-811d5f71fda6",
       "slug": "nucleotide-count",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 2,
       "topics": [
 
-      ],
-      "difficulty": 2
+      ]
     },
     {
+      "uuid": "ab852e36-3968-403f-93f5-53c7ecafa4c8",
       "slug": "difference-of-squares",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 2,
       "topics": [
 
-      ],
-      "difficulty": 2
+      ]
     },
     {
+      "uuid": "2972e0de-b5ca-4fdd-9dbf-648937763394",
       "slug": "triangle",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 2,
       "topics": [
 
-      ],
-      "difficulty": 2
+      ]
     },
     {
+      "uuid": "5af1c90a-f98d-4682-885b-9770c9223194",
       "slug": "sum-of-multiples",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
 
-      ],
-      "difficulty": 3
+      ]
     },
     {
+      "uuid": "8f0570ae-223f-4da4-8b84-268b797b28ad",
       "slug": "anagram",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
 
-      ],
-      "difficulty": 3
+      ]
     },
     {
+      "uuid": "d8e38780-d04e-43fc-8606-97dc71e4974b",
       "slug": "atbash-cipher",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
 
-      ],
-      "difficulty": 3
+      ]
     },
     {
+      "uuid": "668f3947-3142-485e-89f8-e0e5060be29d",
       "slug": "phone-number",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
 
-      ],
-      "difficulty": 3
+      ]
     },
     {
+      "uuid": "24ae9a43-4e1c-418b-97f6-2c83dbc0e14a",
       "slug": "gigasecond",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
 
-      ],
-      "difficulty": 3
+      ]
     },
     {
+      "uuid": "4f5045d5-9ae1-4bdb-ac0b-a5d279a60ed8",
       "slug": "scrabble-score",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 3,
       "topics": [
 
-      ],
-      "difficulty": 3
+      ]
     },
     {
+      "uuid": "a2d4ca29-54e2-4969-bfc9-ee483acf9caf",
       "slug": "robot-simulator",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
 
-      ],
-      "difficulty": 4
+      ]
     },
     {
+      "uuid": "67bbcc69-31b7-41f2-a8e1-5a07d30e00d6",
       "slug": "grade-school",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
 
-      ],
-      "difficulty": 4
+      ]
     },
     {
+      "uuid": "43df8921-f0c3-4a0c-9bdf-eb89405049ad",
       "slug": "word-count",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
 
-      ],
-      "difficulty": 4
+      ]
     },
     {
+      "uuid": "df90c039-8629-497a-a809-5ba2d1f8d52f",
       "slug": "clock",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
 
-      ],
-      "difficulty": 4
+      ]
     },
     {
+      "uuid": "51af2614-e349-4e90-b917-177a6017e786",
       "slug": "allergies",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
 
-      ],
-      "difficulty": 4
+      ]
     },
     {
+      "uuid": "85e23906-6fd8-486a-add8-a6c932cef7e3",
       "slug": "all-your-base",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
 
-      ],
-      "difficulty": 4
+      ]
     },
     {
+      "uuid": "9ca527d7-5065-4856-8c95-07deb664da7e",
       "slug": "series",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
 
-      ],
-      "difficulty": 4
+      ]
     },
     {
+      "uuid": "be69c23b-7559-44fe-9e21-94a865199de7",
       "slug": "parallel-letter-frequency",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
 
-      ],
-      "difficulty": 4
+      ]
     },
     {
+      "uuid": "d8ee01b3-307e-4835-a7cd-331e771111ae",
       "slug": "roman-numerals",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 4,
       "topics": [
 
-      ],
-      "difficulty": 4
+      ]
     },
     {
+      "uuid": "b312ff0e-90e3-4dd8-99dc-df4a9deb1907",
       "slug": "largest-series-product",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
 
-      ],
-      "difficulty": 5
+      ]
     },
     {
+      "uuid": "8ad0c97b-189d-46ac-bb72-2c72f1fe4728",
       "slug": "rotational-cipher",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 5,
       "topics": [
 
-      ],
-      "difficulty": 5
+      ]
     },
     {
+      "uuid": "60fc4ea6-28b0-4914-bcc3-a0caefca3cb5",
       "slug": "etl",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 6,
       "topics": [
 
-      ],
-      "difficulty": 6
+      ]
     },
     {
+      "uuid": "a7e2e89c-c599-4e30-a944-a9d4a98f2b94",
       "slug": "bank-account",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 6,
       "topics": [
 
-      ],
-      "difficulty": 6
+      ]
     },
     {
+      "uuid": "e938c3e6-0b0f-498e-a3ec-47251f5bb55c",
       "slug": "luhn",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 6,
       "topics": [
 
-      ],
-      "difficulty": 6
+      ]
     },
     {
+      "uuid": "249d0c9f-dadc-4168-ba9b-0c6bfe83618d",
       "slug": "meetup",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 6,
       "topics": [
 
-      ],
-      "difficulty": 6
+      ]
     },
     {
+      "uuid": "058b48a9-03ec-43bc-88eb-9dbce8b79e59",
       "slug": "circular-buffer",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 7,
       "topics": [
 
-      ],
-      "difficulty": 7
+      ]
     },
     {
+      "uuid": "2fedc6bf-6006-4c2d-bba7-9c66265b6f62",
       "slug": "beer-song",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 7,
       "topics": [
 
-      ],
-      "difficulty": 7
+      ]
     },
     {
+      "uuid": "b6c242d3-40d5-484d-8466-1a32d2332288",
       "slug": "zipper",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 8,
       "topics": [
 
-      ],
-      "difficulty": 8
+      ]
     },
     {
+      "uuid": "625ad6f2-c9e8-4129-a290-057209f941c5",
       "slug": "spiral-matrix",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 8,
       "topics": [
 
-      ],
-      "difficulty": 8
+      ]
     }
-  ],
-  "deprecated": [
-    "point-mutations",
-    "binary",
-    "trinary",
-    "octal",
-    "hexadecimal"
   ],
   "foregone": [
     "binary-search",


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

active: false is the equivalent of _deprecated_, which was stored in a separate array. This array is being removed in this change.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.


See https://github.com/exercism/meta/issues/16