### PR TITLE
set @etrepum an alumnus, remove NULL fields

### DIFF
--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -13,12 +13,7 @@
     {
       "github_username": "etrepum",
       "show_on_website": false,
-      "alumnus": false,
-      "name": null,
-      "bio": null,
-      "link_text": null,
-      "link_url": null,
-      "avatar_url": null
+      "alumnus": true
     },
     {
       "github_username": "NobbZ",


### PR DESCRIPTION
As @etrepum mentioned in #173, he is currently not able to participate in the exercism project anymore.

Therefore we want to list him as an alumnus.

Until he says otherwise, I will also hide him from the web-display.