### PR TITLE
Add default introductory code example

### DIFF
--- a/docs/SNIPPET.txt
+++ b/docs/SNIPPET.txt
@@ -1,0 +1,8 @@
+-module(example).
+-export([hello/0, test_version/0]).
+
+hello() ->
+  "Hello, World!".
+
+test_version() ->
+  2.


### PR DESCRIPTION
Instead of having logic for a fallback in the backend, we're choosing a
default for the snippet file.

For tracks that have core exercises, we pick the first core exercise.
For tracks without these, we pick the first exercise listed in the config.


See https://github.com/exercism/meta/issues/89