### PR TITLE
Luhn: update tests to canonical data as in #129

### DIFF
--- a/exercises/luhn/test/luhn_tests.erl
+++ b/exercises/luhn/test/luhn_tests.erl
@@ -6,13 +6,21 @@
 
 
 invalid_test() ->
-  ?assertNot(?TESTED_MODULE:valid("1111")),
-  ?assertNot(?TESTED_MODULE:valid("738")).
+  ?assertNot(?TESTED_MODULE:valid("1")),
+  ?assertNot(?TESTED_MODULE:valid("0")),
+  ?assertNot(?TESTED_MODULE:valid("055 444 286")),
+  ?assertNot(?TESTED_MODULE:valid("8273 1232 7352 0569")),
+  ?assertNot(?TESTED_MODULE:valid("055a 444 285")),
+  ?assertNot(?TESTED_MODULE:valid("055-444-285")),
+  ?assertNot(?TESTED_MODULE:valid("055£ 444$ 285")),
+  ?assertNot(?TESTED_MODULE:valid(" 0")).
 
 valid_test() ->
-  ?assert(?TESTED_MODULE:valid("8739567")),
-  ?assert(?TESTED_MODULE:valid("8763")),
-  ?assert(?TESTED_MODULE:valid("2323 2005 7766 3554")).
+  ?assert(?TESTED_MODULE:valid("059")),
+  ?assert(?TESTED_MODULE:valid("59")),
+  ?assert(?TESTED_MODULE:valid("055 444 285")),
+  ?assert(?TESTED_MODULE:valid("0000 0")),
+  ?assert(?TESTED_MODULE:valid("091")).
 
 create_test() ->
   ?assertEqual("2323 2005 7766 3554", ?TESTED_MODULE:create("2323 2005 7766 355")).


### PR DESCRIPTION
As described in #129, the canonical data for luhn tests was changed. These changes are now reflected in the erlang tests.