### PR TITLE
docs: fix dead link in ABOUT.md

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -2,4 +2,4 @@ Erlang is a programming language used to build massively scalable soft real-time
 Some of its uses are in telecoms, banking, e-commerce, computer telephony and instant messaging.
 Erlang's runtime system has built-in support for concurrency, distribution and fault tolerance.
 
-The above description is a quote taken directly from the 'Getting Started' section of [the Erlang homepage](www.erlang.org).
+The above description is a quote taken directly from the 'Getting Started' section of [the Erlang homepage](https://www.erlang.org).


### PR DESCRIPTION
I noticed that the current link in `ABOUT.md` takes you to [http://exercism.io/languages/erlang/www.erlang.org](http://exercism.io/languages/erlang/www.erlang.org) (when viewed from [http://exercism.io/languages/erlang](http://exercism.io/languages/erlang)) instead of the Erlang homepage, as intended.