### PR TITLE
Add pascals-triangle problem to erlang

### DIFF
--- a/config.json
+++ b/config.json
@@ -451,7 +451,15 @@
       "topics": [
 
       ]
-    }
+    },
+    {
+      "uuid": "589b763c-2b3a-11e8-b467-0ed5f89f718b",
+      "slug": "pascals-triangle",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 6,
+      "topics": []
+    }    
   ],
   "foregone": [
     "binary-search",

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -1,0 +1,64 @@
+# Pascal's Triangle
+
+Compute Pascal's triangle up to a given number of rows.
+
+In Pascal's Triangle each number is computed by adding the numbers to
+the right and left of the current position in the previous row.
+
+```text
+    1
+   1 1
+  1 2 1
+ 1 3 3 1
+1 4 6 4 1
+# ... etc
+```
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+### Test versioning
+
+Each problem defines a macro `TEST_VERSION` in the test file and
+verifies that the solution defines and exports a function `test_version`
+returning that same value.
+
+To make tests pass, add the following to your solution:
+
+```erlang
+-export([test_version/0]).
+
+test_version() ->
+  1.
+```
+
+The benefit of this is that reviewers can see against which test version
+an iteration was written if, for example, a previously posted solution
+does not solve the current problem or passes current tests.
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+Pascal's Triangle at Wolfram Math World [http://mathworld.wolfram.com/PascalsTriangle.html](http://mathworld.wolfram.com/PascalsTriangle.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pascals-triangle/rebar.config
+++ b/exercises/pascals-triangle/rebar.config
@@ -1,0 +1,30 @@
+%% Erlang compiler options
+{erl_opts, [debug_info]}.
+
+{deps, [{erl_exercism, "0.1.1"}]}.
+
+{dialyzer, [
+  {warnings, [underspecs, no_return]},
+  {get_warnings, true},
+  {plt_apps, top_level_deps}, % top_level_deps | all_deps
+  {plt_extra_apps, []},
+  {plt_location, local}, % local | "/my/file/name"
+  {plt_prefix, "rebar3"},
+  {base_plt_apps, [stdlib, kernel, crypto]},
+  {base_plt_location, global}, % global | "/my/file/name"
+  {base_plt_prefix, "rebar3"}
+]}.
+
+%% eunit:test(Tests)
+{eunit_tests, []}.
+%% Options for eunit:test(Tests, Opts)
+{eunit_opts, [verbose]}.
+
+%% == xref ==
+
+{xref_warnings, true}.
+
+%% xref checks to run
+{xref_checks, [undefined_function_calls, undefined_functions,
+  locals_not_used, exports_not_used,
+  deprecated_function_calls, deprecated_functions]}.

--- a/exercises/pascals-triangle/src/example.erl
+++ b/exercises/pascals-triangle/src/example.erl
@@ -1,0 +1,30 @@
+-module(example).
+
+-export([gen_pascals_triangle/1, test_version/0]).
+
+gen_pascals_triangle(N) when N < 0 -> -1;
+gen_pascals_triangle(0) -> [];
+gen_pascals_triangle(N) -> 
+	gen_pascals_triangle_helper(1, N, []).
+
+gen_pascals_triangle_helper(Count, N, CurrentResult) ->
+	case Count > N of 
+		true -> CurrentResult;
+		false -> 
+			gen_pascals_triangle_helper(
+				Count + 1, 
+				N, 
+				CurrentResult ++ gen_next(CurrentResult))
+	end.
+
+gen_next([]) -> [[1]];
+gen_next(CurrentResult) ->
+	LastRowDropLast = lists:droplast(lists:last(CurrentResult)),
+	ReverseLastRowDropLast = lists:reverse(LastRowDropLast),
+	ZipList = lists:zipwith(
+		fun(X, Y) -> X + Y end,
+		LastRowDropLast, 
+		ReverseLastRowDropLast),
+	[[1] ++ ZipList ++ [1]].
+
+test_version() -> 1.

--- a/exercises/pascals-triangle/src/pascals_triangle.app.src
+++ b/exercises/pascals-triangle/src/pascals_triangle.app.src
@@ -1,0 +1,9 @@
+{application, pascals_triangle,
+  [{description, "exercism.io - pascals-triangle"},
+    {vsn, "0.0.1"},
+    {modules, []},
+    {registered, []},
+    {applications, [kernel,
+      stdlib]},
+    {env, []}
+  ]}.

--- a/exercises/pascals-triangle/src/pascals_triangle.erl
+++ b/exercises/pascals-triangle/src/pascals_triangle.erl
@@ -1,0 +1,8 @@
+-module(pascals_triangle).
+
+-export([gen_pascals_triangle/1, test_version/0]).
+
+gen_pascals_triangle(N) -> 
+	undefined.
+
+test_version() -> 1.

--- a/exercises/pascals-triangle/test/pascals_triangle_tests.erl
+++ b/exercises/pascals-triangle/test/pascals_triangle_tests.erl
@@ -1,0 +1,51 @@
+-module(pascals_triangle_tests).
+
+-include_lib("erl_exercism/include/exercism.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+
+% test cases adapted from `x-common//canonical-data.json` @ version: 1.3.0
+
+zero_row_test() ->
+  ?assertEqual([], pascals_triangle:gen_pascals_triangle(0)).
+
+one_row_test() ->
+  ?assertEqual([[1]], pascals_triangle:gen_pascals_triangle(1)).
+
+two_rows_test() ->
+  ?assertEqual([[1], [1, 1]], pascals_triangle:gen_pascals_triangle(2)).
+
+three_rows_test() ->
+  ?assertEqual([[1], [1, 1], [1, 2, 1]], pascals_triangle:gen_pascals_triangle(3)).
+
+four_rows_test() ->
+  ?assertEqual(
+    [[1], [1, 1], [1, 2, 1], [1, 3, 3, 1]], 
+    pascals_triangle:gen_pascals_triangle(4)).
+
+five_rows_test() ->
+  ?assertEqual(
+    [[1], [1, 1], [1, 2, 1], [1, 3, 3, 1], [1, 4, 6, 4, 1]], 
+    pascals_triangle:gen_pascals_triangle(5)).
+
+six_rows_test() ->
+  ?assertEqual(
+    [[1], [1, 1], [1, 2, 1], [1, 3, 3, 1], [1, 4, 6, 4, 1], [1, 5, 10, 10, 5, 1]], 
+    pascals_triangle:gen_pascals_triangle(6)).
+
+ten_rows_test() ->
+  ?assertEqual(
+    [[1], 
+    [1, 1], 
+    [1, 2, 1], 
+    [1, 3, 3, 1], 
+    [1, 4, 6, 4, 1], 
+    [1, 5, 10, 10, 5, 1], 
+    [1, 6, 15, 20, 15, 6, 1], 
+    [1, 7, 21, 35, 35, 21, 7, 1], 
+    [1, 8, 28, 56, 70, 56, 28, 8, 1], 
+    [1, 9, 36, 84, 126, 126, 84, 36, 9, 1]],
+    pascals_triangle:gen_pascals_triangle(10)).
+
+negative_rows_test() ->
+  ?assertEqual(-1, pascals_triangle:gen_pascals_triangle(-1)).


### PR DESCRIPTION
Add a new problem: pascals-triangle.
I ran `rebar3 eunit` in my local machine and all test cases passed.

```
pascals-triangle $ rebar3 eunit
===> Verifying dependencies...
===> Compiling pascals_triangle
src/pascals_triangle.erl:5: Warning: variable 'N' is unused

===> Performing EUnit tests...
======================== EUnit ========================
file "pascals_triangle.app"
  application 'pascals_triangle'
    module 'example'
    module 'pascals_triangle'
      module 'pascals_triangle_tests'
        pascals_triangle_tests: zero_row_test...ok
        pascals_triangle_tests: one_row_test...ok
        pascals_triangle_tests: two_rows_test...ok
        pascals_triangle_tests: three_rows_test...ok
        pascals_triangle_tests: four_rows_test...ok
        pascals_triangle_tests: five_rows_test...ok
        pascals_triangle_tests: six_rows_test...ok
        pascals_triangle_tests: ten_rows_test...ok
        pascals_triangle_tests: negative_rows_test...ok
        [done in 0.027 s]
      [done in 0.027 s]
    [done in 0.036 s]
  [done in 0.045 s]
=======================================================
  All 9 tests passed.

```