### PR TITLE
Use ?assertEqual macro instead of ?assert

### DIFF
--- a/exercises/raindrops/test/raindrops_tests.erl
+++ b/exercises/raindrops/test/raindrops_tests.erl
@@ -3,48 +3,59 @@
 -include_lib("erl_exercism/include/exercism.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-% test cases adapted from `x-common//canonical-data.json` @ version: 1.0.0
-
 sound_of_1_is_1_test() ->
-    ?assert( raindrops:convert(1) =:= "1").
+    ?assertEqual("1", raindrops:convert(1)).
+
 sound_of_3_is_Pling_test() ->
-    ?assert( raindrops:convert(3) =:= "Pling").
+    ?assertEqual("Pling", raindrops:convert(3)).
+
 sound_of_5_is_Plang_test() ->
-    ?assert( raindrops:convert(5) =:= "Plang").
+    ?assertEqual("Plang", raindrops:convert(5)).
+
 sound_of_7_is_Plong_test() ->
-    ?assert( raindrops:convert(7) =:= "Plong").
+    ?assertEqual("Plong", raindrops:convert(7)).
 
 sound_of_6_is_Pling_test() ->
-    ?assert( raindrops:convert(6) =:= "Pling").
+    ?assertEqual("Pling", raindrops:convert(6)).
+
 sound_of_2_to_the_power_3_is_8_test() ->
-    ?assert( raindrops:convert(8) =:= "8").
+    ?assertEqual("8", raindrops:convert(8)).
+
 sound_of_9_is_Pling_test() ->
-    ?assert( raindrops:convert(9) =:= "Pling").
+    ?assertEqual("Pling", raindrops:convert(9)).
+
 sound_of_10_is_Plang_test() ->
-    ?assert( raindrops:convert(10) =:= "Plang").
+    ?assertEqual("Plang", raindrops:convert(10)).
+
 sound_of_14_is_Plong_test() ->
-    ?assert( raindrops:convert(14) =:= "Plong").
+    ?assertEqual("Plong", raindrops:convert(14)).
 
 sound_of_15_is_PlingPlang_test() ->
-    ?assert( raindrops:convert(15) =:= "PlingPlang").
+    ?assertEqual("PlingPlang", raindrops:convert(15)).
+
 sound_of_21_is_PlingPlong_test() ->
-    ?assert( raindrops:convert(21) =:= "PlingPlong").
+    ?assertEqual("PlingPlong", raindrops:convert(21)).
+
 sound_of_25_is_Plang_test() ->
-    ?assert( raindrops:convert(25) =:= "Plang").
+    ?assertEqual("Plang", raindrops:convert(25)).
 
 sound_of_27_is_Pling_test() ->
-    ?assert( raindrops:convert(27) =:= "Pling").
+    ?assertEqual("Pling", raindrops:convert(27)).
+
 sound_of_35_is_PlangPlong_test() ->
-    ?assert( raindrops:convert(35) =:= "PlangPlong").
+    ?assertEqual("PlangPlong", raindrops:convert(35)).
+
 sound_of_49_is_Plong_test() ->
-    ?assert( raindrops:convert(49) =:= "Plong").
+    ?assertEqual("Plong", raindrops:convert(49)).
 
 sound_of_52_is_52_test() ->
-    ?assert( raindrops:convert(52) =:= "52").
+    ?assertEqual("52", raindrops:convert(52)).
+
 sound_of_105_is_PlingPlangPlong_test() ->
-    ?assert( raindrops:convert(105) =:= "PlingPlangPlong").
+    ?assertEqual("PlingPlangPlong", raindrops:convert(105)).
+
 sound_of_3125_is_Plang_test() ->
-    ?assert( raindrops:convert(3125) =:= "Plang").
+    ?assertEqual("Plang", raindrops:convert(3125)).
 
 version_test() ->
-  ?assertMatch(1, raindrops:test_version()).
+  ?assertEqual(1, raindrops:test_version()).


### PR DESCRIPTION
It will display incorrect values in test failure messages, which will be more helpful to the programmer.

Closes #242.