### PR TITLE
Module name fixes

### DIFF
--- a/exercises/bracket-push/src/example.erl
+++ b/exercises/bracket-push/src/example.erl
@@ -1,4 +1,4 @@
--module(bracket_push).
+-module(example).
 
 -export([is_paired/1, test_version/0]).
 

--- a/exercises/isbn-verifier/src/example.erl
+++ b/exercises/isbn-verifier/src/example.erl
@@ -1,4 +1,4 @@
--module(isbn_verifier).
+-module(example).
 
 -export([is_valid/1, test_version/0]).
 


### PR DESCRIPTION
I noticed that the examples in the bracket-push and isbn-verifier exercises have wrong module declarations. This PR fixes them.