### PR TITLE
Bump canonical

### DIFF
--- a/exercises/bob/src/bob.erl
+++ b/exercises/bob/src/bob.erl
@@ -5,4 +5,4 @@
 
 response(String) -> undefined.
 
-test_version() -> 2.
+test_version() -> 3.

--- a/exercises/bob/src/example.erl
+++ b/exercises/bob/src/example.erl
@@ -6,13 +6,14 @@
 response(String) ->
   first_match(
     trim(String),
-    [{fun is_silent/1, "Fine. Be that way!"},
+    [{fun is_forceful_question/1, "Calm down, I know what I'm doing!"},
+     {fun is_silent/1, "Fine. Be that way!"},
      {fun is_shouting/1, "Whoa, chill out!"},
      {fun is_question/1, "Sure."},
      {fun (_) -> true end, "Whatever."}]).
 
 test_version() ->
-    2.
+    3.
 
 
 
@@ -28,6 +29,9 @@ is_shouting(String) ->
 
 is_question(String) ->
     lists:last(String) =:= $?.
+
+is_forceful_question(String) ->
+    is_shouting(String) andalso is_question(String).
 
 is_silent("") -> true;
 is_silent(_) -> false.

--- a/exercises/bob/test/bob_tests.erl
+++ b/exercises/bob/test/bob_tests.erl
@@ -40,7 +40,7 @@ using_acronyms_in_regular_speech_test() ->
 			      "DMV.")).
 
 forceful_question_test() ->
-    ?assertMatch("Whoa, chill out!",
+    ?assertMatch("Calm down, I know what I'm doing!",
 		 bob:response("WHAT THE HELL WERE YOU THINKING?")).
 
 shouting_numbers_test() ->
@@ -105,4 +105,4 @@ non_question_ending_with_whitespace_test() ->
 		 bob:response("This is a statement ending with whitespace "
 			      "     ")).
 
-version_test() -> ?assertMatch(2, bob:test_version()).
+version_test() -> ?assertMatch(3, bob:test_version()).

--- a/exercises/complex-numbers/src/complex_numbers.erl
+++ b/exercises/complex-numbers/src/complex_numbers.erl
@@ -26,4 +26,4 @@ real(Z) -> undefined.
 
 sub(Z1, Z2) -> undefined.
 
-test_version() -> 1.
+test_version() -> 2.

--- a/exercises/complex-numbers/src/example.erl
+++ b/exercises/complex-numbers/src/example.erl
@@ -41,4 +41,4 @@ real(#complex{r = A}) ->
 sub(#complex{r = A, i = B}, #complex{r = C, i = D}) ->
     #complex{r = A - C, i = B - D}.
 
-test_version() -> 1.
+test_version() -> 2.

--- a/exercises/complex-numbers/test/complex_numbers_tests.erl
+++ b/exercises/complex-numbers/test/complex_numbers_tests.erl
@@ -6,6 +6,30 @@
 -include_lib("eunit/include/eunit.hrl").
 
 
+real_part_of_a_purely_real_number_test() ->
+    ?assert(1 ==
+	      complex_numbers:real(complex_numbers:new(1, 0))).
+
+real_part_of_a_purely_imaginary_number_test() ->
+    ?assert(0 ==
+	      complex_numbers:real(complex_numbers:new(0, 1))).
+
+real_part_of_a_number_with_real_and_imaginary_part_test() ->
+    ?assert(1 ==
+	      complex_numbers:real(complex_numbers:new(1, 2))).
+
+imaginary_part_of_a_purely_real_number_test() ->
+    ?assert(0 ==
+	      complex_numbers:imaginary(complex_numbers:new(1, 0))).
+
+imaginary_part_of_a_purely_imaginary_number_test() ->
+    ?assert(1 ==
+	      complex_numbers:imaginary(complex_numbers:new(0, 1))).
+
+imaginary_part_of_a_number_with_real_and_imaginary_part_test() ->
+    ?assert(2 ==
+	      complex_numbers:imaginary(complex_numbers:new(1, 2))).
+
 imaginary_unit_test() ->
     ?assert(complex_numbers:equal(complex_numbers:new(-1,
 						      0),
@@ -133,30 +157,6 @@ conjugate_a_number_with_real_and_imaginary_part_test() ->
 				  complex_numbers:conjugate(complex_numbers:new(1,
 										1)))).
 
-real_part_of_a_purely_real_number_test() ->
-    ?assert(1 ==
-	      complex_numbers:real(complex_numbers:new(1, 0))).
-
-real_part_of_a_purely_imaginary_number_test() ->
-    ?assert(0 ==
-	      complex_numbers:real(complex_numbers:new(0, 1))).
-
-real_part_of_a_number_with_real_and_imaginary_part_test() ->
-    ?assert(1 ==
-	      complex_numbers:real(complex_numbers:new(1, 2))).
-
-imaginary_part_of_a_purely_real_number_test() ->
-    ?assert(0 ==
-	      complex_numbers:imaginary(complex_numbers:new(1, 0))).
-
-imaginary_part_of_a_purely_imaginary_number_test() ->
-    ?assert(1 ==
-	      complex_numbers:imaginary(complex_numbers:new(0, 1))).
-
-imaginary_part_of_a_number_with_real_and_imaginary_part_test() ->
-    ?assert(2 ==
-	      complex_numbers:imaginary(complex_numbers:new(1, 2))).
-
 eulers_identityformula_test() ->
     ?assert(complex_numbers:equal(complex_numbers:new(-1,
 						      0),
@@ -174,5 +174,11 @@ exponential_of_a_purely_real_number_test() ->
 				  complex_numbers:exp(complex_numbers:new(1,
 									  0)))).
 
+exponential_of_a_number_with_real_and_imaginary_part_test() ->
+    ?assert(complex_numbers:equal(complex_numbers:new(-2,
+						      0),
+				  complex_numbers:exp(complex_numbers:new(6.93147180559945286227e-1,
+									  3.14159265358979311600)))).
+
 version_test() ->
-    ?assertMatch(1, complex_numbers:test_version()).
+    ?assertMatch(2, complex_numbers:test_version()).

--- a/exercises/custom-set/src/custom_set.erl
+++ b/exercises/custom-set/src/custom_set.erl
@@ -24,4 +24,4 @@ subset(Set1, Set2) -> undefined.
 
 union(Set1, Set2) -> undefined.
 
-test_version() -> 1.
+test_version() -> 2.

--- a/exercises/custom-set/src/example.erl
+++ b/exercises/custom-set/src/example.erl
@@ -48,4 +48,4 @@ subset(#set{s = S1}, #set{s = S2}) ->
 union(#set{s = S1}, #set{s = S2}) ->
 	#set{s = maps:merge(S1, S2)}.
 
-test_version() -> 1.
+test_version() -> 2.

--- a/exercises/custom-set/test/custom_set_tests.erl
+++ b/exercises/custom-set/test/custom_set_tests.erl
@@ -95,6 +95,11 @@ sets_with_different_elements_are_not_equal_test() ->
 						      3]),
 				custom_set:from_list([1, 2, 4]))).
 
+set_is_not_equal_to_larger_set_with_same_elements_test() ->
+    ?assertNot(custom_set:equal(custom_set:from_list([1, 2,
+						      3]),
+				custom_set:from_list([1, 2, 3, 4]))).
+
 add_to_empty_set_test() ->
     ?assertEqual(custom_set:from_list([3]),
 		 custom_set:add(3, custom_set:from_list([]))).
@@ -176,4 +181,4 @@ union_of_non_empty_sets_contains_all_unique_elements_test() ->
 				  custom_set:from_list([2, 3]))).
 
 version_test() ->
-    ?assertMatch(1, custom_set:test_version()).
+    ?assertMatch(2, custom_set:test_version()).

--- a/exercises/leap/src/example.erl
+++ b/exercises/leap/src/example.erl
@@ -9,7 +9,7 @@ leap_year(Year) ->
           not divisible_by(Year, 100)).
 
 test_version() ->
-    3.
+    4.
 
 
 

--- a/exercises/leap/src/leap.erl
+++ b/exercises/leap/src/leap.erl
@@ -5,4 +5,4 @@
 
 leap_year(Year) -> undefined.
 
-test_version() -> 3.
+test_version() -> 4.

--- a/exercises/leap/test/leap_tests.erl
+++ b/exercises/leap/test/leap_tests.erl
@@ -10,7 +10,7 @@ year_not_divisible_by_4_common_year_test() ->
     ?assertNot(leap:leap_year(2015)).
 
 year_divisible_by_4_not_divisible_by_100_leap_year_test() ->
-    ?assert(leap:leap_year(2020)).
+    ?assert(leap:leap_year(1996)).
 
 year_divisible_by_100_not_divisible_by_400_common_year_test() ->
     ?assertNot(leap:leap_year(2100)).
@@ -18,4 +18,4 @@ year_divisible_by_100_not_divisible_by_400_common_year_test() ->
 year_divisible_by_400_leap_year_test() ->
     ?assert(leap:leap_year(2000)).
 
-version_test() -> ?assertMatch(3, leap:test_version()).
+version_test() -> ?assertMatch(4, leap:test_version()).

--- a/exercises/rna-transcription/src/example.erl
+++ b/exercises/rna-transcription/src/example.erl
@@ -2,14 +2,10 @@
 -export([to_rna/1, test_version/0]).
 
 to_rna(Strand) ->
-    try lists:map(fun transcribe_to_rna/1, Strand) of
-        Result -> Result
-    catch
-        _:_ -> error
-    end.
+    lists:map(fun transcribe_to_rna/1, Strand).
 
 test_version() ->
-    2.
+    3.
 
 
 

--- a/exercises/rna-transcription/src/rna_transcription.erl
+++ b/exercises/rna-transcription/src/rna_transcription.erl
@@ -5,4 +5,4 @@
 
 to_rna(Strand) -> undefined.
 
-test_version() -> 2.
+test_version() -> 3.

--- a/exercises/rna-transcription/test/rna_transcription_tests.erl
+++ b/exercises/rna-transcription/test/rna_transcription_tests.erl
@@ -22,15 +22,5 @@ rna_complement_test() ->
     ?assertMatch("UGCACCAGAAUU",
 		 rna_transcription:to_rna("ACGTGGTCTTAA")).
 
-correctly_handles_invalid_input_rna_instead_of_dna_test() ->
-    ?assertMatch(error, rna_transcription:to_rna("U")).
-
-correctly_handles_completely_invalid_dna_input_test() ->
-    ?assertMatch(error, rna_transcription:to_rna("XXX")).
-
-correctly_handles_partially_invalid_dna_input_test() ->
-    ?assertMatch(error,
-		 rna_transcription:to_rna("ACGTXXXCTTAA")).
-
 version_test() ->
-    ?assertMatch(2, rna_transcription:test_version()).
+    ?assertMatch(3, rna_transcription:test_version()).

--- a/testgen/src/tgen_bob.erl
+++ b/testgen/src/tgen_bob.erl
@@ -14,11 +14,11 @@ available() ->
 
 version() -> 2.
 
-generate_test(F = #{description := Desc, expected := Exp, property := Prop, input := Input}) ->
+generate_test(F = #{description := Desc, expected := Exp, property := Prop, input := #{heyBob := HeyBob}}) ->
     TestName = tgen:to_test_name(Desc),
     Property = binary_to_list(Prop),
     Expected = binary_to_list(Exp),
-    Sentence = binary_to_list(Input),
+    Sentence = binary_to_list(HeyBob),
 
     Fn = tgs:simple_fun(TestName, [
         tgs:call_macro("assertMatch", [

--- a/testgen/src/tgen_bob.erl
+++ b/testgen/src/tgen_bob.erl
@@ -12,7 +12,7 @@
 available() ->
     true.
 
-version() -> 2.
+version() -> 3.
 
 generate_test(F = #{description := Desc, expected := Exp, property := Prop, input := #{heyBob := HeyBob}}) ->
     TestName = tgen:to_test_name(Desc),

--- a/testgen/src/tgen_collatz-conjecture.erl
+++ b/testgen/src/tgen_collatz-conjecture.erl
@@ -25,7 +25,7 @@ generate_test(#{description := Desc, expected := #{error := Message}, property :
                 tgs:value(Num)])])]),
 
     {ok, Fn, [{Prop, ["N"]}]};
-generate_test(#{description := Desc, expected := Exp, property := Prop, number := Num}) ->
+generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{number := Num}}) ->
     TestName = tgen:to_test_name(Desc),
     Property = binary_to_list(Prop),
 

--- a/testgen/src/tgen_collatz-conjecture.erl
+++ b/testgen/src/tgen_collatz-conjecture.erl
@@ -14,7 +14,7 @@ available() ->
 
 version() -> 2.
 
-generate_test(#{description := Desc, expected := #{error := Message}, property := Prop, number := Num}) ->
+generate_test(#{description := Desc, expected := #{error := Message}, property := Prop, input := #{number := Num}}) ->
     TestName = tgen:to_test_name(Desc),
     Property = binary_to_list(Prop),
 

--- a/testgen/src/tgen_complex-numbers.erl
+++ b/testgen/src/tgen_complex-numbers.erl
@@ -16,7 +16,7 @@ version() -> 1.
 
 generate_test(F = #{description := Desc, cases := Cases}) ->
     rewrap(lists:flatten(lists:map(fun generate_test/1, Cases)), {[], []});
-generate_test(#{description := Desc, expected := Exp, property := Prop, input := Z}) when is_number(Exp) ->
+generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{z := Z}}) when is_number(Exp) ->
     TestName = tgen:to_test_name(Desc),
     Property = binary_to_list(Prop),
 
@@ -31,7 +31,7 @@ generate_test(#{description := Desc, expected := Exp, property := Prop, input :=
                     tgs:call_fun("complex_numbers:new", lists:map(fun tgs:value/1, Cplx))]))])]),
 
     {ok, Fn, [{Property, ["Z"]}]};
-generate_test(#{description := Desc, expected := Exp, property := Prop, input := Z}) ->
+generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{z := Z}}) ->
     TestName = tgen:to_test_name(Desc),
     Property = binary_to_list(Prop),
 
@@ -46,9 +46,9 @@ generate_test(#{description := Desc, expected := Exp, property := Prop, input :=
                     tgs:call_fun("complex_numbers:new", lists:map(fun tgs:value/1, Cplx))])])])]),
 
     {ok, Fn, [{Property, ["Z"]}]};
-generate_test(#{description := Desc, expected := Exp, property := <<"div">>, z1 := Z1, z2 := Z2}) ->
-    generate_test(#{description => Desc, expected => Exp, property => <<"divide">>, z1 => Z1, z2 => Z2});
-generate_test(#{description := Desc, expected := Exp, property := Prop, z1 := Z1, z2 := Z2}) ->
+generate_test(#{description := Desc, expected := Exp, property := <<"div">>, input := #{z1 := Z1, z2 := Z2}}) ->
+    generate_test(#{description => Desc, expected => Exp, property => <<"divide">>, input => #{z1 => Z1, z2 => Z2}});
+generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{z1 := Z1, z2 := Z2}}) ->
     TestName = tgen:to_test_name(Desc),
     Property = binary_to_list(Prop),
 
@@ -71,5 +71,6 @@ rewrap([{ok, Fn, Props}|Tail], {Fns, AccProps}) ->
     rewrap(Tail, {[Fn|Fns], Props ++ AccProps}).
 
 to_num(N) when is_number(N) -> N;
+to_num(<<"ln(2)">>) -> math:log(2);
 to_num(<<"pi">>) -> math:pi();
 to_num(<<"e">>) -> math:exp(1).

--- a/testgen/src/tgen_complex-numbers.erl
+++ b/testgen/src/tgen_complex-numbers.erl
@@ -12,7 +12,7 @@
 available() ->
     true.
 
-version() -> 1.
+version() -> 2.
 
 generate_test(F = #{description := Desc, cases := Cases}) ->
     rewrap(lists:flatten(lists:map(fun generate_test/1, Cases)), {[], []});

--- a/testgen/src/tgen_custom-set.erl
+++ b/testgen/src/tgen_custom-set.erl
@@ -12,7 +12,7 @@
 available() ->
     true.
 
-version() -> 1.
+version() -> 2.
 
 generate_test(#{description := _, cases := Cases}) ->
     rewrap(lists:flatten(lists:map(fun generate_test/1, Cases)), {[], []});

--- a/testgen/src/tgen_custom-set.erl
+++ b/testgen/src/tgen_custom-set.erl
@@ -16,7 +16,7 @@ version() -> 1.
 
 generate_test(#{description := _, cases := Cases}) ->
     rewrap(lists:flatten(lists:map(fun generate_test/1, Cases)), {[], []});
-generate_test(F=#{description := Desc, expected := Exp, property := Prop, set1 := Set1, set2 := Set2}) when is_list(Exp) ->
+generate_test(F=#{description := Desc, expected := Exp, property := Prop, input := #{set1 := Set1, set2 := Set2}}) when is_list(Exp) ->
     TestName = tgen:to_test_name(Desc),
     Property = binary_to_list(Prop),
 
@@ -29,7 +29,7 @@ generate_test(F=#{description := Desc, expected := Exp, property := Prop, set1 :
                 tgs:call_fun("custom_set:from_list", [tgs:value(Set2)])])])]),
 
     {ok, Fn, [{Property, ["Set1", "Set2"]}]};
-generate_test(F=#{description := Desc, expected := Exp, property := Prop, set1 := Set1, set2 := Set2}) when Exp =:= true; Exp =:= false ->
+generate_test(F=#{description := Desc, expected := Exp, property := Prop, input := #{set1 := Set1, set2 := Set2}}) when Exp =:= true; Exp =:= false ->
     TestName = tgen:to_test_name(Desc),
     Property = binary_to_list(Prop),
 
@@ -45,7 +45,7 @@ generate_test(F=#{description := Desc, expected := Exp, property := Prop, set1 :
                 tgs:call_fun("custom_set:from_list", [tgs:value(Set2)])])])]),
 
     {ok, Fn, [{Property, ["Set1", "Set2"]}, {"from_list", ["List"]}]};
-generate_test(#{description := Desc, expected := Exp, property := Prop, set := Set, element := Elem}) when is_list(Exp) ->
+generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{set := Set, element := Elem}}) when is_list(Exp) ->
     TestName = tgen:to_test_name(Desc),
     Property = binary_to_list(Prop),
 
@@ -59,7 +59,7 @@ generate_test(#{description := Desc, expected := Exp, property := Prop, set := S
                     erl_syntax:abstract(Set)])])])]),
 
     {ok, Fn, [{Property, ["Elem", "Set"]}, {"from_list", ["List"]}]};
-generate_test(#{description := Desc, expected := Exp, property := Prop, set := Set, element := Elem}) when Exp =:= true; Exp =:= false ->
+generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{set := Set, element := Elem}}) when Exp =:= true; Exp =:= false ->
     TestName = tgen:to_test_name(Desc),
     Property = binary_to_list(Prop),
 
@@ -76,7 +76,7 @@ generate_test(#{description := Desc, expected := Exp, property := Prop, set := S
                     erl_syntax:abstract(Set)])])])]),
 
     {ok, Fn, [{Property, ["Elem", "Set"]}, {"from_list", ["List"]}]};
-generate_test(#{description := Desc, expected := Exp, property := <<"empty">>, set := Set}) when Exp =:= true; Exp =:= false ->
+generate_test(#{description := Desc, expected := Exp, property := <<"empty">>, input := #{set := Set}}) when Exp =:= true; Exp =:= false ->
     TestName = tgen:to_test_name(Desc),
     Property = binary_to_list(<<"empty">>),
 

--- a/testgen/src/tgen_hamming.erl
+++ b/testgen/src/tgen_hamming.erl
@@ -27,7 +27,7 @@ generate_test(#{description := Desc, expected := #{error := Message}, property :
                 tgs:value(binary_to_list(S2))])])]),
 
     {ok, Fn, [{Property, ["Strand1", "Strand2"]}]};
-generate_test(#{description := Desc, expected := Exp, property := Prop, 'strand1' := S1, 'strand2' := S2}) ->
+generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{strand1 := S1, strand2 := S2}}) ->
     TestName = tgen:to_test_name(Desc),
     Property = binary_to_list(Prop),
 

--- a/testgen/src/tgen_hamming.erl
+++ b/testgen/src/tgen_hamming.erl
@@ -14,7 +14,7 @@ available() ->
 
 version() -> 2.
 
-generate_test(#{description := Desc, expected := #{error := Message}, property := Prop, 'strand1' := S1, 'strand2' := S2}) ->
+generate_test(#{description := Desc, expected := #{error := Message}, property := Prop, input := #{strand1 := S1, strand2 := S2}}) ->
     TestName = tgen:to_test_name(Desc),
     Property = binary_to_list(Prop),
     Reason = binary_to_list(Message),

--- a/testgen/src/tgen_leap.erl
+++ b/testgen/src/tgen_leap.erl
@@ -14,7 +14,7 @@ available() ->
 
 version() -> 3.
 
-generate_test(#{description := Desc, expected := Exp, property := <<"leapYear">>, input := In}) ->
+generate_test(#{description := Desc, expected := Exp, property := <<"leapYear">>, input := #{year := Year}}) ->
     TestName = tgen:to_test_name(Desc),
     Property = "leap_year",
 
@@ -26,6 +26,6 @@ generate_test(#{description := Desc, expected := Exp, property := <<"leapYear">>
     Fn = tgs:simple_fun(TestName, [
         tgs:call_macro(Assert, [
             tgs:call_fun("leap:" ++ Property, [
-                tgs:value(In)])])]),
+                tgs:value(Year)])])]),
 
     {ok, Fn, [{Property, ["Year"]}]}.

--- a/testgen/src/tgen_leap.erl
+++ b/testgen/src/tgen_leap.erl
@@ -12,7 +12,7 @@
 available() ->
     true.
 
-version() -> 3.
+version() -> 4.
 
 generate_test(#{description := Desc, expected := Exp, property := <<"leapYear">>, input := #{year := Year}}) ->
     TestName = tgen:to_test_name(Desc),

--- a/testgen/src/tgen_rna-transcription.erl
+++ b/testgen/src/tgen_rna-transcription.erl
@@ -14,7 +14,7 @@ available() ->
 
 version() -> 2.
 
-generate_test(#{description := Desc, expected := null, property := <<"toRna">>, dna := DNA}) ->
+generate_test(#{description := Desc, expected := null, property := <<"toRna">>, input := #{dna := DNA}}) ->
     TestName = tgen:to_test_name(Desc),
     Property = "to_rna",
 
@@ -25,7 +25,7 @@ generate_test(#{description := Desc, expected := null, property := <<"toRna">>, 
                 tgs:value(binary_to_list(DNA))])])]),
 
     {ok, Fn, [{Property, ["Strand"]}]};
-generate_test(#{description := Desc, expected := Exp, property := <<"toRna">>, dna := DNA}) ->
+generate_test(#{description := Desc, expected := Exp, property := <<"toRna">>, input := #{dna := DNA}}) ->
     TestName = tgen:to_test_name(Desc),
     Property = "to_rna",
 

--- a/testgen/src/tgen_rna-transcription.erl
+++ b/testgen/src/tgen_rna-transcription.erl
@@ -12,7 +12,7 @@
 available() ->
     true.
 
-version() -> 2.
+version() -> 3.
 
 generate_test(#{description := Desc, expected := null, property := <<"toRna">>, input := #{dna := DNA}}) ->
     TestName = tgen:to_test_name(Desc),


### PR DESCRIPTION
This bumps the canonical data to a much more current version.

Most tests are getting generated and also all but `bob` seem to still pass the testsuite. Bob has therefore already been bumped.

But many other testsuites have been touched by the generator and I need to check over the next days if thats just because of some reordering of tests or if there actually is a bump necessary.