### PR TITLE
Add 'mathematics' topic to relevant exercises in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -49,6 +49,7 @@
       "difficulty": 1,
       "topics": [
         "control_flow_conditionals",
+        "mathematics",
         "pattern_matching"
       ]
     },
@@ -94,8 +95,8 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
-        "lists",
-        "control_flow_conditionals"
+        "control_flow_conditionals",
+        "lists"
       ]
     },
     {
@@ -240,8 +241,8 @@
       "unlocked_by": "accumulate",
       "difficulty": 3,
       "topics": [
-        "lists",
         "filtering",
+        "lists",
         "strings"
       ]
     },


### PR DESCRIPTION
The new site lets people filter optional exercises by topic, and this
makes it easy for people to skip past them.

This is important since the math-y exercises are not key to learning
the language, and a lot of people find them intimidating and demotivating.


I'm opening this PR to help stimulate discussion--please discuss in exercism/exercism.io#4110