### PR TITLE
Re-normalize config (again)

### DIFF
--- a/config.json
+++ b/config.json
@@ -94,8 +94,8 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
-        "lists",
-        "control_flow_conditionals"
+        "control_flow_conditionals",
+        "lists"
       ]
     },
     {
@@ -240,8 +240,8 @@
       "unlocked_by": "accumulate",
       "difficulty": 3,
       "topics": [
-        "lists",
         "filtering",
+        "lists",
         "strings"
       ]
     },


### PR DESCRIPTION
It looks like the config was changed without running fmt.
This normalizes so we can add topics to exercises with a clean diff.