### PR TITLE
update for the sieve exercise

### DIFF
--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -5,8 +5,8 @@ number.
 
 The Sieve of Eratosthenes is a simple, ancient algorithm for finding all
 prime numbers up to any given limit. It does so by iteratively marking as
-composite (i.e. not prime) the multiples of each prime,
-starting with the multiples of 2.
+composite (i.e. not prime) the multiples of each prime, starting with the
+multiples of 2. It does not use any division or remainder operation.
 
 Create your range, starting at two and continuing up to and including the given limit. (i.e. [2, limit])
 
@@ -25,7 +25,9 @@ https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes
 
 Notice that this is a very specific algorithm, and the tests don't check
 that you've implemented the algorithm, only that you've come up with the
-correct list of primes.
+correct list of primes. A good first test is to check that you do not use
+division or remainder operations (div, /, mod or % depending on the
+language).
 
 ## Running tests
 
@@ -42,25 +44,6 @@ directory.
 ```bash
 $ rebar3 eunit
 ```
-
-### Test versioning
-
-Each problem defines a macro `TEST_VERSION` in the test file and
-verifies that the solution defines and exports a function `test_version`
-returning that same value.
-
-To make tests pass, add the following to your solution:
-
-```erlang
--export([test_version/0]).
-
-test_version() ->
-  1.
-```
-
-The benefit of this is that reviewers can see against which test version
-an iteration was written if, for example, a previously posted solution
-does not solve the current problem or passes current tests.
 
 ## Questions?
 

--- a/exercises/sieve/src/example.erl
+++ b/exercises/sieve/src/example.erl
@@ -1,16 +1,31 @@
 -module(example).
 
--export([sieve/1, test_version/0]).
+-export([sieve/1]).
 
-sieve(N) when N < 2 ->
-    [];
+%% This implementation incorporates the refinements
+%% from https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes
+
+sieve(N) when N<2 ->
+	[];
 sieve(N) ->
-    sieve(lists:seq(2,N), []).
+	sieve(lists:seq(3, N, 2), [2], trunc(math:sqrt(N))+1).
 
-sieve([], P) ->
-    lists:reverse(P);
-sieve([N|S], P) ->
-    R = lists:filter(fun(X) -> X rem N /= 0 end, S),
-    sieve(R, [N|P]).
+sieve([P|Candidates], Acc, StopAt) when P<StopAt ->
+	NewCandidates=filter_candidates(P, Candidates),
+	sieve(NewCandidates, [P|Acc], StopAt);
+sieve(Primes, Acc, _) ->
+	lists:reverse(Acc)++Primes.
 
-test_version() -> 1.
+
+filter_candidates(P, Candidates) ->
+	filter_candidates(P, P*P, Candidates, []).
+
+filter_candidates(_, _, [], Acc) ->
+	lists:reverse(Acc);
+filter_candidates(P, N, [C|Candidates], Acc) when C=:=N ->
+	filter_candidates(P, N+2*P, Candidates, Acc);
+filter_candidates(P, N, [C|Candidates], Acc) when C<N ->
+	filter_candidates(P, N, Candidates, [C|Acc]);
+filter_candidates(P, N, Candidates, Acc) ->
+	filter_candidates(P, N+2*P, Candidates, Acc).
+

--- a/exercises/sieve/src/sieve.erl
+++ b/exercises/sieve/src/sieve.erl
@@ -1,8 +1,6 @@
 -module(sieve).
 
--export([sieve/1, test_version/0]).
+-export([sieve/1]).
 
 sieve(_N) ->
   undefined.
-
-test_version() -> 1.

--- a/exercises/sieve/test/sieve_tests.erl
+++ b/exercises/sieve/test/sieve_tests.erl
@@ -1,3 +1,6 @@
+%% based on canonical data version 1.1.0
+%% https://raw.githubusercontent.com/exercism/problem-specifications/master/exercises/sieve/canonical-data.json
+
 -module(sieve_tests).
 
 -include_lib("erl_exercism/include/exercism.hrl").
@@ -35,6 +38,3 @@ primes_up_to_1000_test() ->
         877, 881, 883, 887, 907, 911, 919, 929, 937, 941,
         947, 953, 967, 971, 977, 983, 991, 997 ],
       sieve:sieve(1000)).
-
-version_test() ->
-  ?assertMatch(1, sieve:test_version()).


### PR DESCRIPTION
One crucial point of the Sieve of Eratothenes algorithm is to _avoid_ trial division. The older instructions didn't mention/stress that point. Most students' solutions (all of the few I have seen so far in mentoring), my own first iteration, and even the example solution, thus relied on trial division.

The `description.md` in the problem specifications has been updated lately to reflect that, but the Erlang tracks instructions lag behind in that regard. This update addresses this by
* updating the `README.md` according to the updated problem specifications' `description.md`
* updating the example solution accordingly

The `description.md` contains some language agnostic notes regarding division and remainder operators (lines 29 and 30 in the generated `README.md`). I wasn't sure if I should change that to be specific to the Erlang track (namely, to `div` and `rem`) in the generated `README.md`, so I left in the language agnostic part for now.

Taking further into account the changes requested in #278, this update also
* removes the `test_version/0` function and export from the module skeleton (`src/sieve.erl`)
* removes the `test_version/0` function and export from the example solution (`src/example.erl`)
* removes the version test from the tests (`test/sieve_tests.erl`)
* removes the "Test versioning" paragraph from `README.md`