### PR TITLE
update for the armstrong-numbers exercise

### DIFF
--- a/exercises/armstrong-numbers/README.md
+++ b/exercises/armstrong-numbers/README.md
@@ -1,3 +1,5 @@
+# Armstrong Numbers
+
 An [Armstrong number](https://en.wikipedia.org/wiki/Narcissistic_number) is a number that is the sum of its own digits each raised to the power of the number of digits.
 
 For example:
@@ -25,25 +27,6 @@ directory.
 $ rebar3 eunit
 ```
 
-### Test versioning
-
-Each problem defines a macro `TEST_VERSION` in the test file and
-verifies that the solution defines and exports a function `test_version`
-returning that same value.
-
-To make tests pass, add the following to your solution:
-
-```erlang
--export([test_version/0]).
-
-test_version() ->
-  1.
-```
-
-The benefit of this is that reviewers can see against which test version
-an iteration was written if, for example, a previously posted solution
-does not solve the current problem or passes current tests.
-
 ## Questions?
 
 For detailed information about the Erlang track, please refer to the
@@ -51,3 +34,9 @@ For detailed information about the Erlang track, please refer to the
 This covers the basic information on setting up the development
 environment expected by the exercises.
 
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Narcissistic_number](https://en.wikipedia.org/wiki/Narcissistic_number)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/armstrong-numbers/src/armstrong_numbers.erl
+++ b/exercises/armstrong-numbers/src/armstrong_numbers.erl
@@ -1,8 +1,6 @@
 -module(armstrong_numbers).
 
--export([is_armstrong_number/1, test_version/0]).
+-export([is_armstrong_number/1]).
 
 is_armstrong_number(_N) ->
 	undefined.
-
-test_version() -> 1.

--- a/exercises/armstrong-numbers/src/example.erl
+++ b/exercises/armstrong-numbers/src/example.erl
@@ -1,6 +1,6 @@
 -module(example).
 
--export([is_armstrong_number/1, test_version/0]).
+-export([is_armstrong_number/1]).
 
 is_armstrong_number(N) ->
 	{Digits, Count}=to_digits(N),
@@ -25,5 +25,3 @@ to_digits(N, Digits, Count) ->
 	Digit=N rem 10,
 	NewN=N div 10,
 	to_digits(NewN, [Digit|Digits], Count+1).
-
-test_version() -> 1.

--- a/exercises/armstrong-numbers/test/armstrong_numbers_tests.erl
+++ b/exercises/armstrong-numbers/test/armstrong_numbers_tests.erl
@@ -3,8 +3,6 @@
 
 -module(armstrong_numbers_tests).
 
--define(TESTED_MODULE, (sut(armstrong_numbers))).
--define(TEST_VERSION, 1).
 -include_lib("erl_exercism/include/exercism.hrl").
 -include_lib("eunit/include/eunit.hrl").
 


### PR DESCRIPTION
This PR updates `README.md` with changes made via `configlet generate`, namely it adds the exercise name at the top, and the "Source" and "Submitting Incomplete Solutions" at the bottom.

Further, the changes requested in #278 are implemented:
* Remove the "Test versioning" paragraph from `README.md`
* Remove the `test_version/0` functions and exports from the module skeleton and example implementation
* Remove the test version related `define`s from the tests (there was no version test in it, must have forgotten that when I implemented that exercise for the Erlang track)