### PR TITLE
update for the bracket-push exercise

### DIFF
--- a/exercises/bracket-push/README.md
+++ b/exercises/bracket-push/README.md
@@ -1,5 +1,8 @@
-Given a string containing brackets `[]`, braces `{}` and parentheses `()`,
-verify that all the pairs are matched and nested correctly.
+# Bracket Push
+
+Given a string containing brackets `[]`, braces `{}`, parentheses `()`,
+or any combination thereof, verify that any and all pairs are matched
+and nested correctly.
 
 ## Running tests
 
@@ -17,25 +20,6 @@ directory.
 $ rebar3 eunit
 ```
 
-### Test versioning
-
-Each problem defines a macro `TEST_VERSION` in the test file and
-verifies that the solution defines and exports a function `test_version`
-returning that same value.
-
-To make tests pass, add the following to your solution:
-
-```erlang
--export([test_version/0]).
-
-test_version() ->
-  1.
-```
-
-The benefit of this is that reviewers can see against which test version
-an iteration was written if, for example, a previously posted solution
-does not solve the current problem or passes current tests.
-
 ## Questions?
 
 For detailed information about the Erlang track, please refer to the
@@ -43,3 +27,9 @@ For detailed information about the Erlang track, please refer to the
 This covers the basic information on setting up the development
 environment expected by the exercises.
 
+## Source
+
+Ginna Baker
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bracket-push/src/bracket_push.erl
+++ b/exercises/bracket-push/src/bracket_push.erl
@@ -1,7 +1,5 @@
 -module(bracket_push).
 
--export([is_paired/1, test_version/0]).
+-export([is_paired/1]).
 
 is_paired(_Str) -> undefined.
-
-test_version() -> 1.

--- a/exercises/bracket-push/src/example.erl
+++ b/exercises/bracket-push/src/example.erl
@@ -1,6 +1,6 @@
 -module(example).
 
--export([is_paired/1, test_version/0]).
+-export([is_paired/1]).
 
 is_paired(Str) -> is_paired(Str, []).
 
@@ -11,5 +11,3 @@ is_paired([$]|More], [$[|Stack]) -> is_paired(More, Stack);
 is_paired([$)|More], [$(|Stack]) -> is_paired(More, Stack);
 is_paired([C|_], _) when C=:=$} orelse C=:=$] orelse C=:=$)-> false;
 is_paired([_|More], Stack) -> is_paired(More, Stack).
-
-test_version() -> 1.

--- a/exercises/bracket-push/test/bracket_push_tests.erl
+++ b/exercises/bracket-push/test/bracket_push_tests.erl
@@ -50,6 +50,3 @@ math_expression_test() ->
 
 complex_latex_expression_test()	->
 	?assert(bracket_push:is_paired("\\left(\\begin{array}{cc} \\frac{1}{3} & x\\\\ \\mathrm{e}^{x} &... x^2	\\end{array}\\right)")).
-
-version_test() -> ?assertMatch(1, bracket_push:test_version()).
-


### PR DESCRIPTION
This PR updates `README.md` with changes made via `configlet generate`, namely it adds the exercise name at the top, an augmentation in the first paragraph of the exercise description, and the "Source" and "Submitting Incomplete Solutions" at the bottom.

Further, the changes requested in #278 are implemented:

* Remove the "Test versioning" paragraph from `README.md`
*Remove the `test_version/0` functions and exports from the module skeleton and example implementation
* Remove the version test from the tests