### PR TITLE
update for the change exercise

### DIFF
--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -1,3 +1,5 @@
+# Change
+
 Correctly determine the fewest number of coins to be given to a customer such
 that the sum of the coins' value would equal the correct amount of change.
 
@@ -30,25 +32,6 @@ directory.
 $ rebar3 eunit
 ```
 
-### Test versioning
-
-Each problem defines a macro `TEST_VERSION` in the test file and
-verifies that the solution defines and exports a function `test_version`
-returning that same value.
-
-To make tests pass, add the following to your solution:
-
-```erlang
--export([test_version/0]).
-
-test_version() ->
-  1.
-```
-
-The benefit of this is that reviewers can see against which test version
-an iteration was written if, for example, a previously posted solution
-does not solve the current problem or passes current tests.
-
 ## Questions?
 
 For detailed information about the Erlang track, please refer to the
@@ -56,3 +39,9 @@ For detailed information about the Erlang track, please refer to the
 This covers the basic information on setting up the development
 environment expected by the exercises.
 
+## Source
+
+Software Craftsmanship - Coin Change Kata [https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata](https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/change/src/change.erl
+++ b/exercises/change/src/change.erl
@@ -1,8 +1,6 @@
 -module(change).
 
--export([find_fewest_coins/2, test_version/0]).
+-export([find_fewest_coins/2]).
 
 find_fewest_coins(_Amount, _Coins) ->
 	undefined.
-
-test_version() -> 1.

--- a/exercises/change/src/example.erl
+++ b/exercises/change/src/example.erl
@@ -1,6 +1,6 @@
 -module(example).
 
--export([find_fewest_coins/2, test_version/0]).
+-export([find_fewest_coins/2]).
 
 find_fewest_coins(0, _) ->
 	[];
@@ -53,7 +53,3 @@ get_change2(Target, MoreCoins, undefined, Acc) ->
 
 get_change2(_, _, Current, _) ->
 	Current.
-
-	 
-
-test_version() -> 1.

--- a/exercises/change/test/change_tests.erl
+++ b/exercises/change/test/change_tests.erl
@@ -3,7 +3,6 @@
 
 -module(change_tests).
 
--define(TEST_VERSION, 1).
 -include_lib("erl_exercism/include/exercism.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -80,7 +79,3 @@ negative_target_test() ->
 	Coins=[1, 2, 5],
 	Expected={error, invalid_target_value},
 	?assertMatch(Expected, change:find_fewest_coins(Target, Coins)).
-
-version_test() ->
-	?assertMatch(?TEST_VERSION, change:test_version()).
-


### PR DESCRIPTION
This PR updates `README.md` with changes made via `configlet generate`, namely it adds the exercise name at the top, and the "Source" and "Submitting Incomplete Solutions" at the bottom.

Further, the changes requested in #278 are implemented:
* Remove the "Test versioning" paragraph from `README.md`
* Remove the `test_version/0` functions and exports from the module skeleton and example implementation
* Remove the test version related `define` and the version test from the tests