### PR TITLE
the variable-length-quantity exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -489,6 +489,18 @@
       ]
     },
     {
+      "slug": "variable-length-quantity",
+      "uuid": "1acd7529-c487-4bea-9146-620b8ad5ef34",
+      "core": false,
+      "unlocked_by": "strain",
+      "difficulty": 5,
+      "topics": [
+        "bitwise_operations",
+        "integers",
+        "transforming"
+      ]
+    },
+    {
       "slug": "etl",
       "uuid": "60fc4ea6-28b0-4914-bcc3-a0caefca3cb5",
       "core": false,

--- a/exercises/variable-length-quantity/README.md
+++ b/exercises/variable-length-quantity/README.md
@@ -1,0 +1,62 @@
+# Variable Length Quantity
+
+Implement variable length quantity encoding and decoding.
+
+The goal of this exercise is to implement [VLQ](https://en.wikipedia.org/wiki/Variable-length_quantity) encoding/decoding.
+
+In short, the goal of this encoding is to encode integer values in a way that would save bytes.
+Only the first 7 bits of each byte is significant (right-justified; sort of like an ASCII byte).
+So, if you have a 32-bit value, you have to unpack it into a series of 7-bit bytes.
+Of course, you will have a variable number of bytes depending upon your integer.
+To indicate which is the last byte of the series, you leave bit #7 clear.
+In all of the preceding bytes, you set bit #7.
+
+So, if an integer is between `0-127`, it can be represented as one byte.
+Although VLQ can deal with numbers of arbitrary sizes, for this exercise we will restrict ourselves to only numbers that fit in a 32-bit unsigned integer.
+Here are examples of integers as 32-bit values, and the variable length quantities that they translate to:
+
+```text
+ NUMBER        VARIABLE QUANTITY
+00000000              00
+00000040              40
+0000007F              7F
+00000080             81 00
+00002000             C0 00
+00003FFF             FF 7F
+00004000           81 80 00
+00100000           C0 80 00
+001FFFFF           FF FF 7F
+00200000          81 80 80 00
+08000000          C0 80 80 00
+0FFFFFFF          FF FF FF 7F
+```
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Source
+
+A poor Splice developer having to implement MIDI encoding/decoding. [https://splice.com](https://splice.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/variable-length-quantity/rebar.config
+++ b/exercises/variable-length-quantity/rebar.config
@@ -1,0 +1,30 @@
+%% Erlang compiler options
+{erl_opts, [debug_info, warnings_as_errors]}.
+
+{deps, [{erl_exercism, "0.1.2"}]}.
+
+{dialyzer, [
+  {warnings, [underspecs, no_return]},
+  {get_warnings, true},
+  {plt_apps, top_level_deps}, % top_level_deps | all_deps
+  {plt_extra_apps, []},
+  {plt_location, local}, % local | "/my/file/name"
+  {plt_prefix, "rebar3"},
+  {base_plt_apps, [stdlib, kernel, crypto]},
+  {base_plt_location, global}, % global | "/my/file/name"
+  {base_plt_prefix, "rebar3"}
+]}.
+
+%% eunit:test(Tests)
+{eunit_tests, []}.
+%% Options for eunit:test(Tests, Opts)
+{eunit_opts, [verbose]}.
+
+%% == xref ==
+
+{xref_warnings, true}.
+
+%% xref checks to run
+{xref_checks, [undefined_function_calls, undefined_functions,
+  locals_not_used, exports_not_used,
+  deprecated_function_calls, deprecated_functions]}.

--- a/exercises/variable-length-quantity/src/example.erl
+++ b/exercises/variable-length-quantity/src/example.erl
@@ -1,0 +1,50 @@
+-module(example).
+
+-export([encode/1, decode/1]).
+
+encode(Integers) ->
+	lists:flatten([encode_integer(I) || I <- Integers]).
+
+encode_integer(Integer) ->
+	<<B1:4, Rest:28>> = <<Integer:32>>,
+	RestBytes=[I || <<I:7>> <= <<Rest:28>>],
+	flag_bytes([B1|RestBytes]).
+
+flag_bytes(Bytes) ->
+	flag_bytes(Bytes, []).
+flag_bytes([], Acc) ->
+	Acc;
+flag_bytes([B], Acc) ->
+	lists:reverse([B|Acc]);
+flag_bytes([0|More], Acc=[]) ->
+	flag_bytes(More, Acc);
+flag_bytes([B|More], Acc) ->
+	flag_bytes(More, [B bor 16#80 | Acc]).
+
+
+
+decode(Integers) ->
+	case get_bytegroups(Integers) of
+		undefined -> undefined;
+		ByteGroups -> [decode_bytegroup(G) || G <- ByteGroups]
+	end.
+
+get_bytegroups(Bytes) ->
+	get_bytegroups(Bytes, false, [[]]).
+
+get_bytegroups([], true, [Last|Acc]) ->
+	lists:reverse([lists:reverse(Last)|Acc]);
+get_bytegroups([], false, _) ->
+	undefined;
+get_bytegroups(More, true, [Last|Acc]) ->
+	get_bytegroups(More, false, [[], lists:reverse(Last)|Acc]);
+get_bytegroups([B|More], false, [Last|Acc]) when B band 16#80=:=16#80 ->
+	get_bytegroups(More, false, [[B band 16#7F|Last]|Acc]);
+get_bytegroups([B|More], false, [Last|Acc]) ->
+	get_bytegroups(More, true, [[B|Last]|Acc]).
+
+decode_bytegroup(Bytes) ->
+	Tmp= << <<I:7/integer>> || I <- Bytes >>,
+	Size=bit_size(Tmp),
+	<<Integer:Size/integer>>=Tmp,
+	Integer.

--- a/exercises/variable-length-quantity/src/variable_length_quantity.app.src
+++ b/exercises/variable-length-quantity/src/variable_length_quantity.app.src
@@ -1,0 +1,9 @@
+{application, variable_length_quantity,
+  [{description, "exercism.io - variable-length-quantity"},
+    {vsn, "0.0.1"},
+    {modules, []},
+    {registered, []},
+    {applications, [kernel,
+      stdlib]},
+    {env, []}
+]}.

--- a/exercises/variable-length-quantity/src/variable_length_quantity.erl
+++ b/exercises/variable-length-quantity/src/variable_length_quantity.erl
@@ -1,0 +1,9 @@
+-module(variable_length_quantity).
+
+-export([encode/1, decode/1]).
+
+encode(_Integers) ->
+	undefined.
+
+decode(_Integers) ->
+	undefined.

--- a/exercises/variable-length-quantity/test/variable_length_quantity_tests.erl
+++ b/exercises/variable-length-quantity/test/variable_length_quantity_tests.erl
@@ -1,0 +1,138 @@
+%% based on canonical data version 1.1.0
+%% https://raw.githubusercontent.com/exercism/problem-specifications/master/exercises/variable-length-quantity/canonical-data.json
+
+-module(variable_length_quantity_tests).
+
+-include_lib("erl_exercism/include/exercism.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+encode_zero_test() ->
+	Input=[0],
+	Expected=[0],
+	?assertMatch(Expected, variable_length_quantity:encode(Input)).
+
+encode_arbitrary_single_byte_test() ->
+	Input=[64],
+	Expected=[64],
+	?assertMatch(Expected, variable_length_quantity:encode(Input)).
+
+encode_largest_single_byte_test() ->
+	Input=[127],
+	Expected=[127],
+	?assertMatch(Expected, variable_length_quantity:encode(Input)).
+
+encode_smallest_double_byte_test() ->
+	Input=[128],
+	Expected=[129,0],
+	?assertMatch(Expected, variable_length_quantity:encode(Input)).
+
+encode_arbitrary_double_byte_test() ->
+	Input=[8192],
+	Expected=[192, 0],
+	?assertMatch(Expected, variable_length_quantity:encode(Input)).
+
+encode_largest_double_byte_test() ->
+	Input=[16383],
+	Expected=[255, 127],
+	?assertMatch(Expected, variable_length_quantity:encode(Input)).
+
+encode_smallest_triple_byte_test() ->
+	Input=[16384],
+	Expected=[129, 128, 0],
+	?assertMatch(Expected, variable_length_quantity:encode(Input)).
+
+encode_arbitrary_triple_byte_test() ->
+	Input=[1048576],
+	Expected=[192, 128, 0],
+	?assertMatch(Expected, variable_length_quantity:encode(Input)).
+
+encode_largest_triple_byte_test() ->
+	Input=[2097151],
+	Expected=[255, 255, 127],
+	?assertMatch(Expected, variable_length_quantity:encode(Input)).
+
+encode_smallest_quadruple_byte_test() ->
+	Input=[2097152],
+	Expected=[129, 128, 128, 0],
+	?assertMatch(Expected, variable_length_quantity:encode(Input)).
+
+encode_arbitrary_quadruple_byte_test() ->
+	Input=[134217728],
+	Expected=[192, 128, 128, 0],
+	?assertMatch(Expected, variable_length_quantity:encode(Input)).
+
+encode_largest_quadruple_byte_test() ->
+	Input=[268435455],
+	Expected=[255, 255, 255, 127],
+	?assertMatch(Expected, variable_length_quantity:encode(Input)).
+
+encode_smallest_quintuple_byte_test() ->
+	Input=[268435456],
+	Expected=[129, 128, 128, 128, 0],
+	?assertMatch(Expected, variable_length_quantity:encode(Input)).
+
+encode_arbitrary_quintuple_byte_test() ->
+	Input=[4278190080],
+	Expected=[143, 248, 128, 128, 0],
+	?assertMatch(Expected, variable_length_quantity:encode(Input)).
+
+encode_maximum_32bit_integer_input_test() ->
+	Input=[4294967295],
+	Expected=[143, 255, 255, 255, 127],
+	?assertMatch(Expected, variable_length_quantity:encode(Input)).
+
+encode_two_single_byte_values_test() ->
+	Input=[64, 127],
+	Expected=[64, 127],
+	?assertMatch(Expected, variable_length_quantity:encode(Input)).
+
+encode_two_multi_byte_values_test() ->
+	Input=[16384, 1193046],
+	Expected=[129, 128, 0, 200, 232, 86],
+	?assertMatch(Expected, variable_length_quantity:encode(Input)).
+
+encode_many_multi_byte_values_test() ->
+	Input=[8192, 1193046, 268435455, 0, 16383, 16384],
+	Expected=[192, 0, 200, 232, 86, 255, 255, 255, 127, 0, 255, 127, 129, 128, 0],
+	?assertMatch(Expected, variable_length_quantity:encode(Input)).
+
+decode_one_byte_test() ->
+	Input=[127],
+	Expected=[127],
+	?assertMatch(Expected, variable_length_quantity:decode(Input)).
+
+decode_two_bytes_test() ->
+	Input=[192, 0],
+	Expected=[8192],
+	?assertMatch(Expected, variable_length_quantity:decode(Input)).
+
+decode_three_bytes_test() ->
+	Input=[255, 255, 127],
+	Expected=[2097151],
+	?assertMatch(Expected, variable_length_quantity:decode(Input)).
+
+decode_four_bytes_test() ->
+	Input=[129, 128, 128, 0],
+	Expected=[2097152],
+	?assertMatch(Expected, variable_length_quantity:decode(Input)).
+
+decode_maximum_32bit_integer_test() ->
+	Input=[143, 255, 255, 255, 127],
+	Expected=[4294967295],
+	?assertMatch(Expected, variable_length_quantity:decode(Input)).
+
+decode_incomplete_sequence_causes_error_test() ->
+	Input=[255],
+	Expected=undefined,
+	?assertMatch(Expected, variable_length_quantity:decode(Input)).
+
+decode_incomplete_sequence_causes_error_even_if_value_is_zero_test() ->
+	Input=[128],
+	Expected=undefined,
+	?assertMatch(Expected, variable_length_quantity:decode(Input)).
+
+decode_multiple_values_test() ->
+	Input=[192, 0, 200, 232, 86, 255, 255, 255, 127, 0, 255, 127, 129, 128, 0] ,
+	Expected=[8192, 1193046, 268435455, 0, 16383, 16384],
+	?assertMatch(Expected, variable_length_quantity:decode(Input)).
+


### PR DESCRIPTION
* unlocked by `strain`, like `run-length-encoding`
* difficulty estimation and topics taken from the `go` track

Considering #278, this exercise implements no test versioning, and the corresponding paragraph is not present in `README.md`