### PR TITLE
update for the crypto-square exercise

### DIFF
--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -1,3 +1,5 @@
+# Crypto Square
+
 Implement the classic method for composing secret messages called a square code.
 
 Given an English text, output the encoded version of that text.
@@ -86,25 +88,6 @@ directory.
 $ rebar3 eunit
 ```
 
-### Test versioning
-
-Each problem defines a macro `TEST_VERSION` in the test file and
-verifies that the solution defines and exports a function `test_version`
-returning that same value.
-
-To make tests pass, add the following to your solution:
-
-```erlang
--export([test_version/0]).
-
-test_version() ->
-  1.
-```
-
-The benefit of this is that reviewers can see against which test version
-an iteration was written if, for example, a previously posted solution
-does not solve the current problem or passes current tests.
-
 ## Questions?
 
 For detailed information about the Erlang track, please refer to the
@@ -112,3 +95,9 @@ For detailed information about the Erlang track, please refer to the
 This covers the basic information on setting up the development
 environment expected by the exercises.
 
+## Source
+
+J Dalbey's Programming Practice problems [http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html](http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/crypto-square/src/crypto_square.erl
+++ b/exercises/crypto-square/src/crypto_square.erl
@@ -1,8 +1,6 @@
 -module(crypto_square).
 
--export([ciphertext/1, test_version/0]).
+-export([ciphertext/1]).
 
 ciphertext(_Plaintext) ->
 	undefined.
-
-test_version() -> 1.

--- a/exercises/crypto-square/src/example.erl
+++ b/exercises/crypto-square/src/example.erl
@@ -1,6 +1,6 @@
 -module(example).
 
--export([ciphertext/1, test_version/0]).
+-export([ciphertext/1]).
 
 ciphertext(Plaintext) ->
 	Normalized=normalize(Plaintext),
@@ -75,5 +75,3 @@ transpose([[]|_]) ->
 
 transpose(Matrix) ->
 	[lists:map(fun hd/1, Matrix) | transpose(lists:map(fun tl/1, Matrix))].
-
-test_version() -> 1.

--- a/exercises/crypto-square/test/crypto_square_tests.erl
+++ b/exercises/crypto-square/test/crypto_square_tests.erl
@@ -3,7 +3,6 @@
 
 -module(crypto_square_tests).
 
--define(TEST_VERSION, 1).
 -include_lib("erl_exercism/include/exercism.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -27,6 +26,3 @@ plaintext_8_chars_test() ->
 
 plaintext_54_chars_test() ->
 	?assertMatch("imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau ", crypto_square:ciphertext("If man was meant to stay on the ground, god would have given us roots.")).
-
-version_test() ->
-	?assertMatch(?TEST_VERSION, crypto_square:test_version()).


### PR DESCRIPTION
This PR updates `README.md` with changes made via `configlet generate`, namely it adds the exercise name at the top, and the "Source" and "Submitting Incomplete Solutions" at the bottom.

Further, the changes requested in #278 are implemented:
* Remove the "Test versioning" paragraph from `README.md`
* Remove the `test_version/0` functions and exports from the module skeleton and example implementation
* Remove the test version related `define` and the version test from the tests