### PR TITLE
update for the dominoes exercise

### DIFF
--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -1,3 +1,5 @@
+# Dominoes
+
 Make a chain of dominoes.
 
 Compute a way to order a given set of dominoes in such a way that they form a
@@ -28,25 +30,6 @@ directory.
 $ rebar3 eunit
 ```
 
-### Test versioning
-
-Each problem defines a macro `TEST_VERSION` in the test file and
-verifies that the solution defines and exports a function `test_version`
-returning that same value.
-
-To make tests pass, add the following to your solution:
-
-```erlang
--export([test_version/0]).
-
-test_version() ->
-  1.
-```
-
-The benefit of this is that reviewers can see against which test version
-an iteration was written if, for example, a previously posted solution
-does not solve the current problem or passes current tests.
-
 ## Questions?
 
 For detailed information about the Erlang track, please refer to the
@@ -54,3 +37,5 @@ For detailed information about the Erlang track, please refer to the
 This covers the basic information on setting up the development
 environment expected by the exercises.
 
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/dominoes/src/dominoes.erl
+++ b/exercises/dominoes/src/dominoes.erl
@@ -1,8 +1,6 @@
 -module(dominoes).
 
--export([can_chain/1, test_version/0]).
+-export([can_chain/1]).
 
 can_chain(_Dominoes) ->
 	undefined.
-
-test_version() -> 1.

--- a/exercises/dominoes/src/example.erl
+++ b/exercises/dominoes/src/example.erl
@@ -1,6 +1,6 @@
 -module(example).
 
--export([can_chain/1, test_version/0]).
+-export([can_chain/1]).
 
 can_chain([]) ->
 	true;
@@ -28,5 +28,3 @@ can_chain(First, Current={_, R}, [MaybeMatch={L, R}|NotVisited], Visited) ->
 
 can_chain(First, Current, [NonMatch|NotVisited], Visited) ->
 	can_chain(First, Current, NotVisited, [NonMatch|Visited]).
-
-test_version() -> 1.

--- a/exercises/dominoes/test/dominoes_tests.erl
+++ b/exercises/dominoes/test/dominoes_tests.erl
@@ -3,7 +3,6 @@
 
 -module(dominoes_tests).
 
--define(TEST_VERSION, 1).
 -include_lib("erl_exercism/include/exercism.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -42,6 +41,3 @@ separate_loops_test() ->
 
 nine_elements_test() ->
 	?assert(dominoes:can_chain([{1,2}, {5,3}, {3,1}, {1,2}, {2,4}, {1,6}, {2,3}, {3,4}, {5,6}])).
-
-version_test() ->
-	?assertMatch(?TEST_VERSION, dominoes:test_version()).


### PR DESCRIPTION
This PR updates `README.md` with changes made via `configlet generate`, namely it adds the exercise name at the top, and the "Submitting Incomplete Solutions" at the bottom.

Further, the changes requested in #278 are implemented:
* Remove the "Test versioning" paragraph from `README.md`
* Remove the `test_version/0` functions and exports from the module skeleton and example implementation
* Remove the test version related `define` and the version test from the tests