### PR TITLE
the connect exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -655,6 +655,18 @@
       "topics": [
         "algorithms"
       ]
+    },
+    {
+      "slug": "connect",
+      "uuid": "211c12df-5254-4abf-850b-a9596b2aba3a",
+      "core": false,
+      "unlocked_by": "raindrops",
+      "difficulty": 8,
+      "topics": [
+        "algorithms",
+        "games",
+        "parsing"
+      ]
     }
   ]
 }

--- a/exercises/connect/README.md
+++ b/exercises/connect/README.md
@@ -1,0 +1,57 @@
+# Connect
+
+Compute the result for a game of Hex / Polygon.
+
+The abstract boardgame known as
+[Hex](https://en.wikipedia.org/wiki/Hex_%28board_game%29) / Polygon /
+CON-TAC-TIX is quite simple in rules, though complex in practice. Two players
+place stones on a rhombus with hexagonal fields. The player to connect his/her
+stones to the opposite side first wins. The four sides of the rhombus are
+divided between the two players (i.e. one player gets assigned a side and the
+side directly opposite it and the other player gets assigned the two other
+sides).
+
+Your goal is to build a program that given a simple representation of a board
+computes the winner (or lack thereof). Note that all games need not be "fair".
+(For example, players may have mismatched piece counts.)
+
+The boards look like this (with spaces added for readability, which won't be in
+the representation passed to your code):
+
+```text
+. O . X .
+ . X X O .
+  O O O X .
+   . X O X O
+    X O O O X
+```
+
+"Player `O`" plays from top to bottom, "Player `X`" plays from left to right. In
+the above example `O` has made a connection from left to right but nobody has
+won since `O` didn't connect top and bottom.
+
+## Running tests
+
+In order to run the tests, issue the following command from the exercise
+directory:
+
+For running the tests provided, `rebar3` is used as it is the official build and
+dependency management tool for erlang now. Please refer to [the tracks installation
+instructions](http://exercism.io/languages/erlang/installation) on how to do that.
+
+In order to run the tests, you can issue the following command from the exercise
+directory.
+
+```bash
+$ rebar3 eunit
+```
+
+## Questions?
+
+For detailed information about the Erlang track, please refer to the
+[help page](http://exercism.io/languages/erlang) on the Exercism site.
+This covers the basic information on setting up the development
+environment expected by the exercises.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/connect/rebar.config
+++ b/exercises/connect/rebar.config
@@ -1,0 +1,30 @@
+%% Erlang compiler options
+{erl_opts, [debug_info, warnings_as_errors]}.
+
+{deps, [{erl_exercism, "0.1.2"}]}.
+
+{dialyzer, [
+  {warnings, [underspecs, no_return]},
+  {get_warnings, true},
+  {plt_apps, top_level_deps}, % top_level_deps | all_deps
+  {plt_extra_apps, []},
+  {plt_location, local}, % local | "/my/file/name"
+  {plt_prefix, "rebar3"},
+  {base_plt_apps, [stdlib, kernel, crypto]},
+  {base_plt_location, global}, % global | "/my/file/name"
+  {base_plt_prefix, "rebar3"}
+]}.
+
+%% eunit:test(Tests)
+{eunit_tests, []}.
+%% Options for eunit:test(Tests, Opts)
+{eunit_opts, [verbose]}.
+
+%% == xref ==
+
+{xref_warnings, true}.
+
+%% xref checks to run
+{xref_checks, [undefined_function_calls, undefined_functions,
+  locals_not_used, exports_not_used,
+  deprecated_function_calls, deprecated_functions]}.

--- a/exercises/connect/src/connect.app.src
+++ b/exercises/connect/src/connect.app.src
@@ -1,0 +1,9 @@
+{application, connect,
+  [{description, "exercism.io - connect"},
+    {vsn, "0.0.1"},
+    {modules, []},
+    {registered, []},
+    {applications, [kernel,
+      stdlib]},
+    {env, []}
+]}.

--- a/exercises/connect/src/connect.erl
+++ b/exercises/connect/src/connect.erl
@@ -1,0 +1,6 @@
+-module(connect).
+
+-export([winner/1]).
+
+winner(_Board) ->
+	undefined.

--- a/exercises/connect/src/example.erl
+++ b/exercises/connect/src/example.erl
@@ -1,0 +1,153 @@
+-module(example).
+
+-export([winner/1]).
+
+winner(Board) ->
+	find_winner(group(parse_board(Board))).
+
+
+parse_board(Board) ->
+	maps:from_list(
+		lists:filter(
+			fun
+				({_, empty}) -> false;
+				(_) -> true
+			end,
+			parse_board(Board, 0, [])
+		)
+	).
+
+parse_board([Row], RowIdx, []) ->
+	parse_row(Row, top_bottom, RowIdx);
+parse_board([Row|More], RowIdx, []) ->
+	parse_board(More, RowIdx+1, [parse_row(Row, top, RowIdx)]);
+parse_board([Row], RowIdx, Acc) ->
+	lists:flatten([parse_row(Row, bottom, RowIdx)|Acc]);
+parse_board([Row|More], RowIdx, Acc) ->
+	parse_board(More, RowIdx+1, [parse_row(Row, inner, RowIdx)|Acc]).
+
+
+parse_row(Row, RowTag, RowIdx) ->
+	parse_row(Row, RowTag, RowIdx, 0, []).
+
+parse_row([], _, _, _, Acc) ->
+	Acc;
+parse_row([16#20|More], RowTag, RowIdx, ColIdx, Acc) ->
+	parse_row(More, RowTag, RowIdx, ColIdx+1, Acc);
+parse_row([$.|More], RowTag, RowIdx, ColIdx, Acc) ->
+	parse_row(More, RowTag, RowIdx, ColIdx+1, [{{ColIdx, RowIdx}, empty}|Acc]);
+parse_row([$X], RowTag, RowIdx, ColIdx, []) ->
+	[{{ColIdx, RowIdx}, {x, {ColIdx, RowIdx}, {left_right, RowTag}}}];
+parse_row([$X|More], RowTag, RowIdx, ColIdx, []) ->
+	parse_row(More, RowTag, RowIdx, ColIdx+1, [{{ColIdx, RowIdx}, {x, {ColIdx, RowIdx}, {left, RowTag}}}]);
+parse_row([$X], RowTag, RowIdx, ColIdx, Acc) ->
+	[{{ColIdx, RowIdx}, {x, {ColIdx, RowIdx}, {right, RowTag}}}|Acc];
+parse_row([$X|More], RowTag, RowIdx, ColIdx, Acc) ->
+	parse_row(More, RowTag, RowIdx, ColIdx+1, [{{ColIdx, RowIdx}, {x, {ColIdx, RowIdx}, {inner, RowTag}}}|Acc]);
+parse_row([$O], RowTag, RowIdx, ColIdx, []) ->
+	[{{ColIdx, RowIdx}, {o, {ColIdx, RowIdx}, {left_right, RowTag}}}];
+parse_row([$O|More], RowTag, RowIdx, ColIdx, []) ->
+	parse_row(More, RowTag, RowIdx, ColIdx+1, [{{ColIdx, RowIdx}, {o, {ColIdx, RowIdx}, {left, RowTag}}}]);
+parse_row([$O], RowTag, RowIdx, ColIdx, Acc) ->
+	[{{ColIdx, RowIdx}, {o, {ColIdx, RowIdx}, {right, RowTag}}}|Acc];
+parse_row([$O|More], RowTag, RowIdx, ColIdx, Acc) ->
+	parse_row(More, RowTag, RowIdx, ColIdx+1, [{{ColIdx, RowIdx}, {o, {ColIdx, RowIdx}, {inner, RowTag}}}|Acc]).
+
+
+get_adjacent({X, Y}, Player, Board) ->
+	maps:filter(
+		fun
+			(_, {P, _, _}) when P=/=Player -> false;
+			({X2, Y2}, _) when X2=:=X-2 andalso Y2=:=Y -> true;
+			({X2, Y2}, _) when X2=:=X+2 andalso Y2=:=Y -> true;
+			({X2, Y2}, _) when X2=:=X+1 andalso Y2=:=Y-1 -> true;
+			({X2, Y2}, _) when X2=:=X-1 andalso Y2=:=Y-1 -> true;
+			({X2, Y2}, _) when X2=:=X+1 andalso Y2=:=Y+1 -> true;
+			({X2, Y2}, _) when X2=:=X-1 andalso Y2=:=Y+1 -> true;
+			(_, _) -> false
+		end,
+		Board
+	).
+
+
+group(Board) ->
+	group(maps:to_list(Board), Board).
+
+group([], Board) ->
+	maps:fold(
+		fun
+			(_, {_, _, {inner, inner}}, Acc) ->
+				Acc;
+
+			(_, {P, G, CRTag}, Acc) ->
+				Acc#{{P, G} => [CRTag|maps:get({P, G}, Acc, [])]}
+		end,
+		#{},
+		Board
+	);
+group([{Coords, {Player, Group, _}}|More], Board) ->
+	Adj=get_adjacent(Coords, Player, Board),
+	Board2=
+	maps:fold(
+		fun
+			(_, {_, Group2, _}, Acc) when Group2=:=Group ->
+				Acc;
+
+			(_, {_, Group2, _}, Acc) ->
+				maps:map(
+					fun
+						(_, {Player3, Group3, CRTag3}) when Group3=:=Group2 -> {Player3, Group, CRTag3};
+						(_, V3) -> V3
+					end,
+					Acc
+				)
+		end,
+		Board,
+		Adj
+	),
+	group(More, Board2).
+
+
+find_winner(Groups) ->
+	maps:fold(
+		fun
+			({o, _}, CRTag, undefined) ->
+				case
+					lists:foldl(
+						fun
+							(_, Acc={true, true}) -> Acc;
+							({_, top}, {_, Acc2}) -> {true, Acc2};
+							({_, bottom}, {Acc1, _}) -> {Acc1, true};
+							({_, top_bottom}, _) -> {true, true};
+							(_, Acc) -> Acc
+						end,
+						{false, false},
+						CRTag
+					)
+				of
+					{true, true} -> o;
+					_ -> undefined
+				end;
+
+			({x, _}, CRTag, undefined) ->
+				case
+					lists:foldl(
+						fun
+							(_, Acc={true, true}) -> Acc;
+							({left, _}, {_, Acc2}) -> {true, Acc2};
+							({right, _}, {Acc1, _}) -> {Acc1, true};
+							({left_right, _}, _) -> {true, true};
+							(_, Acc) -> Acc
+						end,
+						{false, false},
+						CRTag
+					)
+				of
+					{true, true} -> x;
+					_ -> undefined
+				end;
+			(_, _, Acc) -> Acc
+		end,
+		undefined,
+		Groups
+	).

--- a/exercises/connect/test/connect_tests.erl
+++ b/exercises/connect/test/connect_tests.erl
@@ -1,0 +1,112 @@
+%% based on canonical data version 1.1.0
+%% https://raw.githubusercontent.com/exercism/problem-specifications/master/exercises/connect/canonical-data.json
+
+-module(connect_tests).
+
+-include_lib("erl_exercism/include/exercism.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+an_empty_board_has_no_winner_test() ->
+	Input=[
+		". . . . .",
+		" . . . . .",
+		"  . . . . .",
+		"   . . . . .",
+		"    . . . . ."
+	],
+	Expected=undefined,
+	?assertMatch(Expected, connect:winner(Input)).
+
+x_can_win_on_a_1x1_board_test() ->
+	Input=[
+		"X"
+	],
+	Expected=x,
+	?assertMatch(Expected, connect:winner(Input)).
+
+o_can_win_on_a_1x1_board_test() ->
+	Input=[
+		"O"
+	],
+	Expected=o,
+	?assertMatch(Expected, connect:winner(Input)).
+
+only_edges_does_not_make_a_winner_test() ->
+	Input=[
+		"O O O X",
+		" X . . X",
+		"  X . . X",
+		"   X O O O"
+	],
+	Expected=undefined,
+	?assertMatch(Expected, connect:winner(Input)).
+
+illegal_diagonal_does_not_make_a_winner_test() ->
+	Input=[
+		"X O . .",
+		" O X X X",
+		"  O X O .",
+		"   . O X .",
+		"    X X O O"
+	],
+	Expected=undefined,
+	?assertMatch(Expected, connect:winner(Input)).
+
+nobody_wins_crossing_adjacent_angles_test() ->
+	Input=[
+		"X . . .",
+		" . X O .",
+		"  O . X O",
+		"   . O . X",
+		"    . . O ."
+	],
+	Expected=undefined,
+	?assertMatch(Expected, connect:winner(Input)).
+
+x_wins_crossing_from_left_to_right_test() ->
+	Input=[
+		". O . .",
+		" O X X X",
+		"  O X O .",
+		"   X X O X",
+		"    . O X ."
+	],
+	Expected=x,
+	?assertMatch(Expected, connect:winner(Input)).
+
+o_wins_crossing_from_top_to_bottom_test() ->
+	Input=[
+		". O . .",
+		" O X X X",
+		"  O O O .",
+		"   X X O X",
+		"    . O X ."
+	],
+	Expected=o,
+	?assertMatch(Expected, connect:winner(Input)).
+
+x_wins_using_a_convoluted_path_test() ->
+	Input=[
+		". X X . .",
+		" X . X . X",
+		"  . X . X .",
+		"   . X X . .",
+		"    O O O O O"
+	],
+	Expected=x,
+	?assertMatch(Expected, connect:winner(Input)).
+
+x_wins_using_a_spiral_path_test() ->
+	Input=[
+		"O X X X X X X X X",
+		" O X O O O O O O O",
+		"  O X O X X X X X O",
+		"   O X O X O O O X O",
+		"    O X O X X X O X O",
+		"     O X O O O X O X O",
+		"      O X X X X X O X O",
+		"       O O O O O O O X O",
+		"        X X X X X X X X O"
+	],
+	Expected=x,
+	?assertMatch(Expected, connect:winner(Input)).


### PR DESCRIPTION
* unlocked by `raindrops` because there are only few exercises behind it
* difficulty estimation of `8` taken from the `Haskell` track
* topics:
  * `algorithms`: there exists a set of specific algorithms (union-find, quick-find, ...) to solve a problem like this
  * `games` because the exercise is based on a game (Hex/Polygon)
  * `parsing` because the game board (given as a list of strings) needs to be parsed into coordinates etc

Considering #278, this exercise implements no test versioning, and the corresponding paragraph is not present in `README.md`