### PR TITLE
difference-of-squares: renamed square_of_sums to square_of_sum

### DIFF
--- a/exercises/difference-of-squares/src/difference_of_squares.erl
+++ b/exercises/difference-of-squares/src/difference_of_squares.erl
@@ -1,11 +1,11 @@
 -module(difference_of_squares).
 
--export([sum_of_squares/1, square_of_sums/1, difference_of_squares/1, test_version/0]).
+-export([sum_of_squares/1, square_of_sum/1, difference_of_squares/1, test_version/0]).
 
 sum_of_squares(_N) ->
   undefined.
 
-square_of_sums(_N) ->
+square_of_sum(_N) ->
   undefined.
 
 difference_of_squares(_N) ->

--- a/exercises/difference-of-squares/src/example.erl
+++ b/exercises/difference-of-squares/src/example.erl
@@ -1,12 +1,12 @@
 -module(example).
 
--export( [sum_of_squares/1, square_of_sums/1, difference_of_squares/1, test_version/0] ).
+-export( [sum_of_squares/1, square_of_sum/1, difference_of_squares/1, test_version/0] ).
 
 sum_of_squares( N ) -> lists:sum( [square(X) || X <- lists:seq(1, N)] ).
 
-square_of_sums( N ) -> square( lists:sum(lists:seq(1, N)) ).
+square_of_sum( N ) -> square( lists:sum(lists:seq(1, N)) ).
 
-difference_of_squares( N ) -> square_of_sums( N ) - sum_of_squares( N ).
+difference_of_squares( N ) -> square_of_sum( N ) - sum_of_squares( N ).
 
 test_version() ->
     1.

--- a/exercises/difference-of-squares/test/difference_of_squares_tests.erl
+++ b/exercises/difference-of-squares/test/difference_of_squares_tests.erl
@@ -4,19 +4,19 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(assertSumOfSquares(Expected, Number), ?assertEqual(Expected, difference_of_squares:sum_of_squares(Number))).
--define(assertSquareOfSums(Expected, Number), ?assertEqual(Expected, difference_of_squares:square_of_sums(Number))).
+-define(assertSquareOfSum(Expected, Number), ?assertEqual(Expected, difference_of_squares:square_of_sum(Number))).
 -define(assertDifference(Expected, Number), ?assertEqual(Expected, difference_of_squares:difference_of_squares(Number))).
 
 %% Square the sum of the numbers up to the given number
 
-square_of_sums_5_test() ->
-  ?assertSquareOfSums( 225, 5 ).
+square_of_sum_5_test() ->
+  ?assertSquareOfSum( 225, 5 ).
 
-square_of_sums_10_test() ->
-  ?assertSquareOfSums( 3025, 10 ).
+square_of_sum_10_test() ->
+  ?assertSquareOfSum( 3025, 10 ).
 
-square_of_sums_100_test() ->
-  ?assertSquareOfSums( 25502500, 100 ).
+square_of_sum_100_test() ->
+  ?assertSquareOfSum( 25502500, 100 ).
 
 %% Sum the squares of the numbers up to the given number
 
@@ -29,7 +29,7 @@ sum_of_square_10_test() ->
 sum_of_square_100_test() ->
   ?assertSumOfSquares( 338350, 100 ).
 
-%% Subtract sum of squares from square of sums
+%% Subtract sum of squares from square of sum
 
 difference_of_squares_0_test() ->
   ?assertDifference( 0, 0 ).


### PR DESCRIPTION
In exercise difference-of-sums, renamed `square_of_sums` to `square_of_sum` and `assertSquareOfSums` to `assertSquareOfSum`.