### PR TITLE
slugify camelcase to snailcase

### DIFF
--- a/testgen/src/tgen_bob.erl
+++ b/testgen/src/tgen_bob.erl
@@ -13,7 +13,7 @@ available() ->
 
 generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{heyBob := HeyBob}}) ->
     TestName = tgen:to_test_name(Desc),
-    Property = binary_to_list(Prop),
+    Property = tgen:to_property_name(Prop),
     Expected = binary_to_list(Exp),
     Sentence = binary_to_list(HeyBob),
 

--- a/testgen/src/tgen_collatz-conjecture.erl
+++ b/testgen/src/tgen_collatz-conjecture.erl
@@ -13,7 +13,7 @@ available() ->
 
 generate_test(#{description := Desc, expected := #{error := Message}, property := Prop, input := #{number := Num}}) ->
     TestName = tgen:to_test_name(Desc),
-    Property = binary_to_list(Prop),
+    Property = tgen:to_property_name(Prop),
 
     Fn = tgs:simple_fun(TestName, [
         tgs:call_macro("assertMatch", [
@@ -24,7 +24,7 @@ generate_test(#{description := Desc, expected := #{error := Message}, property :
     {ok, Fn, [{Prop, ["N"]}]};
 generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{number := Num}}) ->
     TestName = tgen:to_test_name(Desc),
-    Property = binary_to_list(Prop),
+    Property = tgen:to_property_name(Prop),
 
     Fn = tgs:simple_fun(TestName, [
         tgs:call_macro("assertMatch", [

--- a/testgen/src/tgen_complex-numbers.erl
+++ b/testgen/src/tgen_complex-numbers.erl
@@ -15,7 +15,7 @@ generate_test(#{description := _Desc, cases := Cases}) ->
     rewrap(lists:flatten(lists:map(fun generate_test/1, Cases)), {[], []});
 generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{z := Z}}) when is_number(Exp) ->
     TestName = tgen:to_test_name(Desc),
-    Property = binary_to_list(Prop),
+    Property = tgen:to_property_name(Prop),
 
     Cplx = lists:map(fun to_num/1, Z),
 
@@ -30,7 +30,7 @@ generate_test(#{description := Desc, expected := Exp, property := Prop, input :=
     {ok, Fn, [{Property, ["Z"]}]};
 generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{z := Z}}) ->
     TestName = tgen:to_test_name(Desc),
-    Property = binary_to_list(Prop),
+    Property = tgen:to_property_name(Prop),
 
     Cplx = lists:map(fun to_num/1, Z),
     Expected = lists:map(fun to_num/1, Exp),
@@ -47,7 +47,7 @@ generate_test(#{description := Desc, expected := Exp, property := <<"div">>, inp
     generate_test(#{description => Desc, expected => Exp, property => <<"divide">>, input => #{z1 => Z1, z2 => Z2}});
 generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{z1 := Z1, z2 := Z2}}) ->
     TestName = tgen:to_test_name(Desc),
-    Property = binary_to_list(Prop),
+    Property = tgen:to_property_name(Prop),
 
     Cplx1 = lists:map(fun to_num/1, Z1),
     Cplx2 = lists:map(fun to_num/1, Z2),

--- a/testgen/src/tgen_custom-set.erl
+++ b/testgen/src/tgen_custom-set.erl
@@ -15,7 +15,7 @@ generate_test(#{description := _, cases := Cases}) ->
     rewrap(lists:flatten(lists:map(fun generate_test/1, Cases)), {[], []});
 generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{set1 := Set1, set2 := Set2}}) when is_list(Exp) ->
     TestName = tgen:to_test_name(Desc),
-    Property = binary_to_list(Prop),
+    Property = tgen:to_property_name(Prop),
 
     Fn = tgs:simple_fun(TestName, [
         tgs:call_macro("assertEqual", [
@@ -28,7 +28,7 @@ generate_test(#{description := Desc, expected := Exp, property := Prop, input :=
     {ok, Fn, [{Property, ["Set1", "Set2"]}]};
 generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{set1 := Set1, set2 := Set2}}) when Exp =:= true; Exp =:= false ->
     TestName = tgen:to_test_name(Desc),
-    Property = binary_to_list(Prop),
+    Property = tgen:to_property_name(Prop),
 
     Assert = case Exp of
         true -> "assert";
@@ -44,7 +44,7 @@ generate_test(#{description := Desc, expected := Exp, property := Prop, input :=
     {ok, Fn, [{Property, ["Set1", "Set2"]}, {"from_list", ["List"]}]};
 generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{set := Set, element := Elem}}) when is_list(Exp) ->
     TestName = tgen:to_test_name(Desc),
-    Property = binary_to_list(Prop),
+    Property = tgen:to_property_name(Prop),
 
     Fn = tgs:simple_fun(TestName, [
         tgs:call_macro("assertEqual", [
@@ -58,7 +58,7 @@ generate_test(#{description := Desc, expected := Exp, property := Prop, input :=
     {ok, Fn, [{Property, ["Elem", "Set"]}, {"from_list", ["List"]}]};
 generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{set := Set, element := Elem}}) when Exp =:= true; Exp =:= false ->
     TestName = tgen:to_test_name(Desc),
-    Property = binary_to_list(Prop),
+    Property = tgen:to_property_name(Prop),
 
     Assert = case Exp of
         true -> "assert";
@@ -75,7 +75,7 @@ generate_test(#{description := Desc, expected := Exp, property := Prop, input :=
     {ok, Fn, [{Property, ["Elem", "Set"]}, {"from_list", ["List"]}]};
 generate_test(#{description := Desc, expected := Exp, property := <<"empty">>, input := #{set := Set}}) when Exp =:= true; Exp =:= false ->
     TestName = tgen:to_test_name(Desc),
-    Property = binary_to_list(<<"empty">>),
+    Property = tgen:to_property_name(<<"empty">>),
 
     Assert = case Exp of
         true -> "assert";

--- a/testgen/src/tgen_hamming.erl
+++ b/testgen/src/tgen_hamming.erl
@@ -13,7 +13,7 @@ available() ->
 
 generate_test(#{description := Desc, expected := #{error := Message}, property := Prop, input := #{strand1 := S1, strand2 := S2}}) ->
     TestName = tgen:to_test_name(Desc),
-    Property = binary_to_list(Prop),
+    Property = tgen:to_property_name(Prop),
     Reason = binary_to_list(Message),
 
     Fn = tgs:simple_fun(TestName, [
@@ -26,7 +26,7 @@ generate_test(#{description := Desc, expected := #{error := Message}, property :
     {ok, Fn, [{Property, ["Strand1", "Strand2"]}]};
 generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{strand1 := S1, strand2 := S2}}) ->
     TestName = tgen:to_test_name(Desc),
-    Property = binary_to_list(Prop),
+    Property = tgen:to_property_name(Prop),
 
     Fn = tgs:simple_fun(TestName, [
         tgs:call_macro("assertMatch", [

--- a/testgen/src/tgen_hello-world.erl
+++ b/testgen/src/tgen_hello-world.erl
@@ -14,7 +14,7 @@ available() ->
 generate_test(#{description := Desc, expected := Exp, property := Prop}) ->
     TestName = tgen:to_test_name(Desc),
     Expected = binary_to_list(Exp),
-    Property = binary_to_list(Prop),
+    Property = tgen:to_property_name(Prop),
 
     Fn = tgs:simple_fun(TestName, [
             tgs:call_macro("assertEqual", [

--- a/testgen/src/tgen_leap.erl
+++ b/testgen/src/tgen_leap.erl
@@ -11,9 +11,9 @@
 available() ->
     true.
 
-generate_test(#{description := Desc, expected := Exp, property := <<"leapYear">>, input := #{year := Year}}) ->
+generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{year := Year}}) ->
     TestName = tgen:to_test_name(Desc),
-    Property = "leap_year",
+    Property = tgen:to_property_name(Prop),
 
     Assert = case Exp of
         true -> "assert";

--- a/testgen/src/tgen_rna-transcription.erl
+++ b/testgen/src/tgen_rna-transcription.erl
@@ -11,9 +11,9 @@
 available() ->
     true.
 
-generate_test(#{description := Desc, expected := null, property := <<"toRna">>, input := #{dna := DNA}}) ->
+generate_test(#{description := Desc, expected := null, property := Prop, input := #{dna := DNA}}) ->
     TestName = tgen:to_test_name(Desc),
-    Property = "to_rna",
+    Property = tgen:to_property_name(Prop),
 
     Fn = tgs:simple_fun(TestName, [
         tgs:call_macro("assertMatch", [
@@ -22,9 +22,9 @@ generate_test(#{description := Desc, expected := null, property := <<"toRna">>, 
                 tgs:value(binary_to_list(DNA))])])]),
 
     {ok, Fn, [{Property, ["Strand"]}]};
-generate_test(#{description := Desc, expected := Exp, property := <<"toRna">>, input := #{dna := DNA}}) ->
+generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{dna := DNA}}) ->
     TestName = tgen:to_test_name(Desc),
-    Property = "to_rna",
+    Property = tgen:to_property_name(Prop),
 
     Fn = tgs:simple_fun(TestName, [
         tgs:call_macro("assertMatch", [


### PR DESCRIPTION
`tgen:slugify/1` will now translate camel case (eg, `leapYear`) to snail case (eg, `leap_year`), thereby it can be used to slugify property names as well via `tgen:to_property_name/1`