### PR TITLE
Improve testgen

### DIFF
--- a/testgen/src/tgen_bob.erl
+++ b/testgen/src/tgen_bob.erl
@@ -4,15 +4,15 @@
 
 -export([
     available/0,
-    generate_test/1
+    generate_test/2
 ]).
 
 -spec available() -> true.
 available() ->
     true.
 
-generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{heyBob := HeyBob}}) ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := Exp, property := Prop, input := #{heyBob := HeyBob}}) ->
+    TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(Prop),
     Expected = binary_to_list(Exp),
     Sentence = binary_to_list(HeyBob),

--- a/testgen/src/tgen_bracket-push.erl
+++ b/testgen/src/tgen_bracket-push.erl
@@ -4,15 +4,15 @@
 
 -export([
     available/0,
-    generate_test/1
+    generate_test/2
 ]).
 
 -spec available() -> true.
 available() ->
     true.
 
-generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{value := Val}}) ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := Exp, property := Prop, input := #{value := Val}}) ->
+    TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(Prop),
 
     Assert=case Exp of

--- a/testgen/src/tgen_collatz-conjecture.erl
+++ b/testgen/src/tgen_collatz-conjecture.erl
@@ -4,15 +4,15 @@
 
 -export([
     available/0,
-    generate_test/1
+    generate_test/2
 ]).
 
 -spec available() -> true.
 available() ->
     true.
 
-generate_test(#{description := Desc, expected := #{error := Message}, property := Prop, input := #{number := Num}}) ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := #{error := Message}, property := Prop, input := #{number := Num}}) ->
+    TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(Prop),
 
     Fn = tgs:simple_fun(TestName, [
@@ -22,8 +22,8 @@ generate_test(#{description := Desc, expected := #{error := Message}, property :
                 tgs:value(Num)])])]),
 
     {ok, Fn, [{Prop, ["N"]}]};
-generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{number := Num}}) ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := Exp, property := Prop, input := #{number := Num}}) ->
+    TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(Prop),
 
     Fn = tgs:simple_fun(TestName, [

--- a/testgen/src/tgen_complex-numbers.erl
+++ b/testgen/src/tgen_complex-numbers.erl
@@ -4,17 +4,15 @@
 
 -export([
     available/0,
-    generate_test/1
+    generate_test/2
 ]).
 
 -spec available() -> true.
 available() ->
     true.
 
-generate_test(#{description := _Desc, cases := Cases}) ->
-    rewrap(lists:flatten(lists:map(fun generate_test/1, Cases)), {[], []});
-generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{z := Z}}) when is_number(Exp) ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := Exp, property := Prop, input := #{z := Z}}) when is_number(Exp) ->
+    TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(Prop),
 
     Cplx = lists:map(fun to_num/1, Z),
@@ -28,8 +26,8 @@ generate_test(#{description := Desc, expected := Exp, property := Prop, input :=
                     tgs:call_fun("complex_numbers:new", lists:map(fun tgs:value/1, Cplx))]))])]),
 
     {ok, Fn, [{Property, ["Z"]}]};
-generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{z := Z}}) ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := Exp, property := Prop, input := #{z := Z}}) ->
+    TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(Prop),
 
     Cplx = lists:map(fun to_num/1, Z),
@@ -43,10 +41,10 @@ generate_test(#{description := Desc, expected := Exp, property := Prop, input :=
                     tgs:call_fun("complex_numbers:new", lists:map(fun tgs:value/1, Cplx))])])])]),
 
     {ok, Fn, [{Property, ["Z"]}]};
-generate_test(#{description := Desc, expected := Exp, property := <<"div">>, input := #{z1 := Z1, z2 := Z2}}) ->
-    generate_test(#{description => Desc, expected => Exp, property => <<"divide">>, input => #{z1 => Z1, z2 => Z2}});
-generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{z1 := Z1, z2 := Z2}}) ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := Exp, property := <<"div">>, input := #{z1 := Z1, z2 := Z2}}) ->
+    generate_test(N, #{description => Desc, expected => Exp, property => <<"divide">>, input => #{z1 => Z1, z2 => Z2}});
+generate_test(N, #{description := Desc, expected := Exp, property := Prop, input := #{z1 := Z1, z2 := Z2}}) ->
+    TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(Prop),
 
     Cplx1 = lists:map(fun to_num/1, Z1),
@@ -62,10 +60,6 @@ generate_test(#{description := Desc, expected := Exp, property := Prop, input :=
                     tgs:call_fun("complex_numbers:new", lists:map(fun tgs:value/1, Cplx2))])])])]),
 
     {ok, Fn, [{Property, ["Z1", "Z2"]}, {"equal", ["Z1", "Z2"]}, {"new", ["R", "I"]}]}.
-
-rewrap([], {Fns, Props}) -> {ok, lists:reverse(Fns), Props};
-rewrap([{ok, Fn, Props}|Tail], {Fns, AccProps}) ->
-    rewrap(Tail, {[Fn|Fns], Props ++ AccProps}).
 
 to_num(N) when is_number(N) -> N;
 to_num(<<"ln(2)">>) -> math:log(2);

--- a/testgen/src/tgen_custom-set.erl
+++ b/testgen/src/tgen_custom-set.erl
@@ -4,17 +4,15 @@
 
 -export([
     available/0,
-    generate_test/1
+    generate_test/2
 ]).
 
 -spec available() -> true.
 available() ->
     true.
 
-generate_test(#{description := _, cases := Cases}) ->
-    rewrap(lists:flatten(lists:map(fun generate_test/1, Cases)), {[], []});
-generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{set1 := Set1, set2 := Set2}}) when is_list(Exp) ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := Exp, property := Prop, input := #{set1 := Set1, set2 := Set2}}) when is_list(Exp) ->
+    TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(Prop),
 
     Fn = tgs:simple_fun(TestName, [
@@ -26,8 +24,8 @@ generate_test(#{description := Desc, expected := Exp, property := Prop, input :=
                 tgs:call_fun("custom_set:from_list", [tgs:value(Set2)])])])]),
 
     {ok, Fn, [{Property, ["Set1", "Set2"]}]};
-generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{set1 := Set1, set2 := Set2}}) when Exp =:= true; Exp =:= false ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := Exp, property := Prop, input := #{set1 := Set1, set2 := Set2}}) when Exp =:= true; Exp =:= false ->
+    TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(Prop),
 
     Assert = case Exp of
@@ -42,8 +40,8 @@ generate_test(#{description := Desc, expected := Exp, property := Prop, input :=
                 tgs:call_fun("custom_set:from_list", [tgs:value(Set2)])])])]),
 
     {ok, Fn, [{Property, ["Set1", "Set2"]}, {"from_list", ["List"]}]};
-generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{set := Set, element := Elem}}) when is_list(Exp) ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := Exp, property := Prop, input := #{set := Set, element := Elem}}) when is_list(Exp) ->
+    TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(Prop),
 
     Fn = tgs:simple_fun(TestName, [
@@ -56,8 +54,8 @@ generate_test(#{description := Desc, expected := Exp, property := Prop, input :=
                     erl_syntax:abstract(Set)])])])]),
 
     {ok, Fn, [{Property, ["Elem", "Set"]}, {"from_list", ["List"]}]};
-generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{set := Set, element := Elem}}) when Exp =:= true; Exp =:= false ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := Exp, property := Prop, input := #{set := Set, element := Elem}}) when Exp =:= true; Exp =:= false ->
+    TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(Prop),
 
     Assert = case Exp of
@@ -73,8 +71,8 @@ generate_test(#{description := Desc, expected := Exp, property := Prop, input :=
                     erl_syntax:abstract(Set)])])])]),
 
     {ok, Fn, [{Property, ["Elem", "Set"]}, {"from_list", ["List"]}]};
-generate_test(#{description := Desc, expected := Exp, property := <<"empty">>, input := #{set := Set}}) when Exp =:= true; Exp =:= false ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := Exp, property := <<"empty">>, input := #{set := Set}}) when Exp =:= true; Exp =:= false ->
+    TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(<<"empty">>),
 
     Assert = case Exp of
@@ -89,7 +87,3 @@ generate_test(#{description := Desc, expected := Exp, property := <<"empty">>, i
                     tgs:value(Set)])])])]),
 
     {ok, Fn, [{Property, ["Set"]}, {"from_list", ["List"]}]}.
-
-rewrap([], {Fns, Props}) -> {ok, lists:reverse(Fns), Props};
-rewrap([{ok, Fn, Props}|Tail], {Fns, AccProps}) ->
-    rewrap(Tail, {[Fn|Fns], Props ++ AccProps}).

--- a/testgen/src/tgen_hamming.erl
+++ b/testgen/src/tgen_hamming.erl
@@ -4,15 +4,15 @@
 
 -export([
     available/0,
-    generate_test/1
+    generate_test/2
 ]).
 
 -spec available() -> true.
 available() ->
     true.
 
-generate_test(#{description := Desc, expected := #{error := Message}, property := Prop, input := #{strand1 := S1, strand2 := S2}}) ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := #{error := Message}, property := Prop, input := #{strand1 := S1, strand2 := S2}}) ->
+    TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(Prop),
     Reason = binary_to_list(Message),
 
@@ -24,8 +24,8 @@ generate_test(#{description := Desc, expected := #{error := Message}, property :
                 tgs:value(binary_to_list(S2))])])]),
 
     {ok, Fn, [{Property, ["Strand1", "Strand2"]}]};
-generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{strand1 := S1, strand2 := S2}}) ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := Exp, property := Prop, input := #{strand1 := S1, strand2 := S2}}) ->
+    TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(Prop),
 
     Fn = tgs:simple_fun(TestName, [

--- a/testgen/src/tgen_hello-world.erl
+++ b/testgen/src/tgen_hello-world.erl
@@ -4,15 +4,15 @@
 
 -export([
     available/0,
-    generate_test/1
+    generate_test/2
 ]).
 
 -spec available() -> true.
 available() ->
     true.
 
-generate_test(#{description := Desc, expected := Exp, property := Prop}) ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := Exp, property := Prop}) ->
+    TestName = tgen:to_test_name(N, Desc),
     Expected = binary_to_list(Exp),
     Property = tgen:to_property_name(Prop),
 

--- a/testgen/src/tgen_isbn-verifier.erl
+++ b/testgen/src/tgen_isbn-verifier.erl
@@ -4,15 +4,15 @@
 
 -export([
     available/0,
-    generate_test/1
+    generate_test/2
 ]).
 
 -spec available() -> true.
 available() ->
     true.
 
-generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{isbn := Isbn}}) ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := Exp, property := Prop, input := #{isbn := Isbn}}) ->
+    TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(Prop),
 
     Assert = case Exp of

--- a/testgen/src/tgen_isbn-verifier.erl
+++ b/testgen/src/tgen_isbn-verifier.erl
@@ -1,0 +1,28 @@
+-module('tgen_isbn-verifier').
+
+-behaviour(tgen).
+
+-export([
+    available/0,
+    generate_test/1
+]).
+
+-spec available() -> true.
+available() ->
+    true.
+
+generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{isbn := Isbn}}) ->
+    TestName = tgen:to_test_name(Desc),
+    Property = tgen:to_property_name(Prop),
+
+    Assert = case Exp of
+        true -> "assert";
+        false -> "assertNot"
+    end,
+
+    Fn = tgs:simple_fun(TestName, [
+        tgs:call_macro(Assert, [
+            tgs:call_fun("isbn_verifier:" ++ Property, [
+                tgs:value(binary_to_list(Isbn))])])]),
+
+    {ok, Fn, [{Property, ["Isbn"]}]}.

--- a/testgen/src/tgen_leap.erl
+++ b/testgen/src/tgen_leap.erl
@@ -4,15 +4,15 @@
 
 -export([
     available/0,
-    generate_test/1
+    generate_test/2
 ]).
 
 -spec available() -> true.
 available() ->
     true.
 
-generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{year := Year}}) ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := Exp, property := Prop, input := #{year := Year}}) ->
+    TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(Prop),
 
     Assert = case Exp of

--- a/testgen/src/tgen_raindrops.erl
+++ b/testgen/src/tgen_raindrops.erl
@@ -4,15 +4,15 @@
 
 -export([
     available/0,
-    generate_test/1
+    generate_test/2
 ]).
 
 -spec available() -> true.
 available() ->
     true.
 
-generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{number := Num}}) ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := Exp, property := Prop, input := #{number := Num}}) ->
+    TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(Prop),
 
     Fn = tgs:simple_fun(TestName, [

--- a/testgen/src/tgen_rna-transcription.erl
+++ b/testgen/src/tgen_rna-transcription.erl
@@ -4,15 +4,15 @@
 
 -export([
     available/0,
-    generate_test/1
+    generate_test/2
 ]).
 
 -spec available() -> true.
 available() ->
     true.
 
-generate_test(#{description := Desc, expected := null, property := Prop, input := #{dna := DNA}}) ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := null, property := Prop, input := #{dna := DNA}}) ->
+    TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(Prop),
 
     Fn = tgs:simple_fun(TestName, [
@@ -22,8 +22,8 @@ generate_test(#{description := Desc, expected := null, property := Prop, input :
                 tgs:value(binary_to_list(DNA))])])]),
 
     {ok, Fn, [{Property, ["Strand"]}]};
-generate_test(#{description := Desc, expected := Exp, property := Prop, input := #{dna := DNA}}) ->
-    TestName = tgen:to_test_name(Desc),
+generate_test(N, #{description := Desc, expected := Exp, property := Prop, input := #{dna := DNA}}) ->
+    TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(Prop),
 
     Fn = tgs:simple_fun(TestName, [


### PR DESCRIPTION
* nested tests in canonical data will be flattened
* test functions can (should?) be indexed to avoid duplications
* callback `generate_test/1` augmented to `generate_test/2`, including the test index as first parameter
* callback `generate_test/2` may return `ignore` to ignore a test case, ie, not include it in the test module
* optional callback `prepare_tests/1` which allows addition/removal/modification of test cases to better fit the track