### PR TITLE
Switch foldl expected argument order.

### DIFF
--- a/exercises/list-ops/src/example.erl
+++ b/exercises/list-ops/src/example.erl
@@ -39,7 +39,7 @@ map(Fun, [Curr|Rest], Acc) -> map(Fun, Rest, [Fun(Curr)|Acc]).
 foldl(Fun, Start, L) -> reduce_foldl(Fun, L, Start).
 reduce_foldl(_, [], Acc) -> Acc;
 reduce_foldl(Fun, [Curr|Rest], Acc) ->
-	reduce_foldl(Fun, Rest, Fun(Acc, Curr)).
+	reduce_foldl(Fun, Rest, Fun(Curr, Acc)).
 
 foldr(Fun, Start, L) -> reduce_foldr(Fun, reverse(L), Start).
 

--- a/exercises/list-ops/test/list_ops_tests.erl
+++ b/exercises/list-ops/test/list_ops_tests.erl
@@ -76,7 +76,7 @@ foldr_direction_independent_function_applied_to_non_empty_list_test() ->
 
 foldr_direction_dependent_function_applied_to_non_empty_list_test() ->
 	?assertEqual(2,
-		     list_ops:foldr(fun(X,Y) -> X div Y end, 5, [2,5])).
+		     list_ops:foldr(fun(X,Y) -> Y div X end, 5, [2,5])).
 
 reverse_empty_list_test() ->
 	?assertEqual([],

--- a/exercises/list-ops/test/list_ops_tests.erl
+++ b/exercises/list-ops/test/list_ops_tests.erl
@@ -64,7 +64,7 @@ foldl_direction_independent_function_applied_to_non_empty_list_test() ->
 
 foldl_direction_dependent_function_applied_to_non_empty_list_test() ->
 	?assertEqual(0,
-		     list_ops:foldl(fun(X,Y) -> X div Y end, 5, [2,5])).
+		     list_ops:foldl(fun(X,Y) -> Y div X end, 5, [2,5])).
 
 foldr_empty_list_test() ->
 	?assertEqual(2,
@@ -76,7 +76,7 @@ foldr_direction_independent_function_applied_to_non_empty_list_test() ->
 
 foldr_direction_dependent_function_applied_to_non_empty_list_test() ->
 	?assertEqual(2,
-		     list_ops:foldr(fun(X,Y) -> Y div X end, 5, [2,5])).
+		     list_ops:foldr(fun(X,Y) -> X div Y end, 5, [2,5])).
 
 reverse_empty_list_test() ->
 	?assertEqual([],


### PR DESCRIPTION
Currently, the list-ops tests expect that the function called via foldl/2 uses an argument order that's the inverse of the erlang stdlib. More importantly, it's also the inverse of the foldr/2 test expectation, which seems really weird.

I've no idea how this test was created, but here's a small PR to highlight what I believe to be the issue.
