### PR TITLE
Update exercise template for luhn.

### DIFF
--- a/exercises/luhn/src/luhn.erl
+++ b/exercises/luhn/src/luhn.erl
@@ -1,6 +1,6 @@
 -module(luhn).
 
--export([valid/1, create/1, test_version/0]).
+-export([valid/1, test_version/0]).
 
 valid(_Number) ->
   undefined.

--- a/exercises/luhn/src/luhn.erl
+++ b/exercises/luhn/src/luhn.erl
@@ -5,7 +5,4 @@
 valid(_Number) ->
   undefined.
 
-create(_Number) ->
-  undefined.
-
-test_version() -> 1.
+test_version() -> 2.


### PR DESCRIPTION
This updates the exercise source template to match the test version in
the current test suite. In addition, it removes a function that is not
used in the current test suite.

My guess is that the template was not updated the last time the test suite was?
