### PR TITLE
fix callback name typo

### DIFF
--- a/testgen/src/tgen.erl
+++ b/testgen/src/tgen.erl
@@ -157,7 +157,7 @@ prepare_test_module(Module) ->
 
 prepare_tests(Module, Tests) ->
     {module, Module}=code:ensure_loaded(Module),
-    case erlang:function_exported(Module, prepare_test, 1) of
+    case erlang:function_exported(Module, prepare_tests, 1) of
         true -> Module:prepare_tests(Tests);
         false -> Tests
     end.


### PR DESCRIPTION
typo (or omission in renaming) prevented executaion of `prepare_tests/1` callback