### PR TITLE
update to the test generator and the custom-set exercise

### DIFF
--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -23,25 +23,6 @@ directory.
 $ rebar3 eunit
 ```
 
-### Test versioning
-
-Each problem defines a macro `TEST_VERSION` in the test file and
-verifies that the solution defines and exports a function `test_version`
-returning that same value.
-
-To make tests pass, add the following to your solution:
-
-```erlang
--export([test_version/0]).
-
-test_version() ->
-  1.
-```
-
-The benefit of this is that reviewers can see against which test version
-an iteration was written if, for example, a previously posted solution
-does not solve the current problem or passes current tests.
-
 ## Questions?
 
 For detailed information about the Erlang track, please refer to the

--- a/exercises/custom-set/test/custom_set_tests.erl
+++ b/exercises/custom-set/test/custom_set_tests.erl
@@ -10,176 +10,191 @@
 
 
 
-'1_sets_with_no_elements_are_empty_test'() ->
-    ?assert(custom_set:empty(custom_set:from_list([]))).
-
-'2_sets_with_elements_are_not_empty_test'() ->
-    ?assertNot(custom_set:empty(custom_set:from_list([1]))).
-
-'3_nothing_is_contained_in_an_empty_set_test'() ->
-    ?assertNot(custom_set:contains(1,
-				   custom_set:from_list([]))).
-
-'4_when_the_element_is_in_the_set_test'() ->
-    ?assert(custom_set:contains(1,
-				custom_set:from_list([1, 2, 3]))).
-
-'5_when_the_element_is_not_in_the_set_test'() ->
-    ?assertNot(custom_set:contains(4,
-				   custom_set:from_list([1, 2, 3]))).
-
-'6_empty_set_is_a_subset_of_another_empty_set_test'() ->
-    ?assert(custom_set:subset(custom_set:from_list([]),
-			      custom_set:from_list([]))).
-
-'7_empty_set_is_a_subset_of_non_empty_set_test'() ->
-    ?assert(custom_set:subset(custom_set:from_list([]),
-			      custom_set:from_list([1]))).
-
-'8_non_empty_set_is_not_a_subset_of_empty_set_test'() ->
-    ?assertNot(custom_set:subset(custom_set:from_list([1]),
-				 custom_set:from_list([]))).
-
-'9_set_is_a_subset_of_set_with_exact_same_elements_test'() ->
-    ?assert(custom_set:subset(custom_set:from_list([1, 2,
-						    3]),
-			      custom_set:from_list([1, 2, 3]))).
-
-'10_set_is_a_subset_of_larger_set_with_same_elements_test'() ->
-    ?assert(custom_set:subset(custom_set:from_list([1, 2,
-						    3]),
-			      custom_set:from_list([4, 1, 2, 3]))).
-
-'11_set_is_not_a_subset_of_set_that_does_not_contain_its_elements_test'() ->
-    ?assertNot(custom_set:subset(custom_set:from_list([1, 2,
-						       3]),
-				 custom_set:from_list([4, 1, 3]))).
-
-'12_the_empty_set_is_disjoint_with_itself_test'() ->
-    ?assert(custom_set:disjoint(custom_set:from_list([]),
-				custom_set:from_list([]))).
-
-'13_empty_set_is_disjoint_with_non_empty_set_test'() ->
-    ?assert(custom_set:disjoint(custom_set:from_list([]),
-				custom_set:from_list([1]))).
-
-'14_non_empty_set_is_disjoint_with_empty_set_test'() ->
-    ?assert(custom_set:disjoint(custom_set:from_list([1]),
-				custom_set:from_list([]))).
-
-'15_sets_are_not_disjoint_if_they_share_an_element_test'() ->
-    ?assertNot(custom_set:disjoint(custom_set:from_list([1,
-							 2]),
-				   custom_set:from_list([2, 3]))).
-
-'16_sets_are_disjoint_if_they_share_no_elements_test'() ->
-    ?assert(custom_set:disjoint(custom_set:from_list([1,
-						      2]),
-				custom_set:from_list([3, 4]))).
-
-'17_empty_sets_are_equal_test'() ->
+'1_empty_sets_are_equal_test'() ->
     ?assert(custom_set:equal(custom_set:from_list([]),
 			     custom_set:from_list([]))).
 
-'18_empty_set_is_not_equal_to_non_empty_set_test'() ->
+'2_empty_set_is_not_equal_to_non_empty_set_test'() ->
     ?assertNot(custom_set:equal(custom_set:from_list([]),
 				custom_set:from_list([1, 2, 3]))).
 
-'19_non_empty_set_is_not_equal_to_empty_set_test'() ->
+'3_non_empty_set_is_not_equal_to_empty_set_test'() ->
     ?assertNot(custom_set:equal(custom_set:from_list([1, 2,
 						      3]),
 				custom_set:from_list([]))).
 
-'20_sets_with_the_same_elements_are_equal_test'() ->
+'4_sets_with_the_same_elements_are_equal_test'() ->
     ?assert(custom_set:equal(custom_set:from_list([1, 2]),
 			     custom_set:from_list([2, 1]))).
 
-'21_sets_with_different_elements_are_not_equal_test'() ->
+'5_sets_with_different_elements_are_not_equal_test'() ->
     ?assertNot(custom_set:equal(custom_set:from_list([1, 2,
 						      3]),
 				custom_set:from_list([1, 2, 4]))).
 
-'22_set_is_not_equal_to_larger_set_with_same_elements_test'() ->
+'6_set_is_not_equal_to_larger_set_with_same_elements_test'() ->
     ?assertNot(custom_set:equal(custom_set:from_list([1, 2,
 						      3]),
 				custom_set:from_list([1, 2, 3, 4]))).
 
+'7_sets_with_no_elements_are_empty_test'() ->
+    ?assert(custom_set:empty(custom_set:from_list([]))).
+
+'8_sets_with_elements_are_not_empty_test'() ->
+    ?assertNot(custom_set:empty(custom_set:from_list([1]))).
+
+'9_nothing_is_contained_in_an_empty_set_test'() ->
+    ?assertNot(custom_set:contains(1,
+				   custom_set:from_list([]))).
+
+'10_when_the_element_is_in_the_set_test'() ->
+    ?assert(custom_set:contains(1,
+				custom_set:from_list([1, 2, 3]))).
+
+'11_when_the_element_is_not_in_the_set_test'() ->
+    ?assertNot(custom_set:contains(4,
+				   custom_set:from_list([1, 2, 3]))).
+
+'12_empty_set_is_a_subset_of_another_empty_set_test'() ->
+    ?assert(custom_set:subset(custom_set:from_list([]),
+			      custom_set:from_list([]))).
+
+'13_empty_set_is_a_subset_of_non_empty_set_test'() ->
+    ?assert(custom_set:subset(custom_set:from_list([]),
+			      custom_set:from_list([1]))).
+
+'14_non_empty_set_is_not_a_subset_of_empty_set_test'() ->
+    ?assertNot(custom_set:subset(custom_set:from_list([1]),
+				 custom_set:from_list([]))).
+
+'15_set_is_a_subset_of_set_with_exact_same_elements_test'() ->
+    ?assert(custom_set:subset(custom_set:from_list([1, 2,
+						    3]),
+			      custom_set:from_list([1, 2, 3]))).
+
+'16_set_is_a_subset_of_larger_set_with_same_elements_test'() ->
+    ?assert(custom_set:subset(custom_set:from_list([1, 2,
+						    3]),
+			      custom_set:from_list([4, 1, 2, 3]))).
+
+'17_set_is_not_a_subset_of_set_that_does_not_contain_its_elements_test'() ->
+    ?assertNot(custom_set:subset(custom_set:from_list([1, 2,
+						       3]),
+				 custom_set:from_list([4, 1, 3]))).
+
+'18_the_empty_set_is_disjoint_with_itself_test'() ->
+    ?assert(custom_set:disjoint(custom_set:from_list([]),
+				custom_set:from_list([]))).
+
+'19_empty_set_is_disjoint_with_non_empty_set_test'() ->
+    ?assert(custom_set:disjoint(custom_set:from_list([]),
+				custom_set:from_list([1]))).
+
+'20_non_empty_set_is_disjoint_with_empty_set_test'() ->
+    ?assert(custom_set:disjoint(custom_set:from_list([1]),
+				custom_set:from_list([]))).
+
+'21_sets_are_not_disjoint_if_they_share_an_element_test'() ->
+    ?assertNot(custom_set:disjoint(custom_set:from_list([1,
+							 2]),
+				   custom_set:from_list([2, 3]))).
+
+'22_sets_are_disjoint_if_they_share_no_elements_test'() ->
+    ?assert(custom_set:disjoint(custom_set:from_list([1,
+						      2]),
+				custom_set:from_list([3, 4]))).
+
 '23_add_to_empty_set_test'() ->
-    ?assertEqual(custom_set:from_list([3]),
-		 custom_set:add(3, custom_set:from_list([]))).
+    ?assert(custom_set:equal(custom_set:from_list([3]),
+			     custom_set:add(3, custom_set:from_list([])))).
 
 '24_add_to_non_empty_set_test'() ->
-    ?assertEqual(custom_set:from_list([1, 2, 3, 4]),
-		 custom_set:add(3, custom_set:from_list([1, 2, 4]))).
+    ?assert(custom_set:equal(custom_set:from_list([1, 2, 3,
+						   4]),
+			     custom_set:add(3,
+					    custom_set:from_list([1, 2, 4])))).
 
 '25_adding_an_existing_element_does_not_change_the_set_test'() ->
-    ?assertEqual(custom_set:from_list([1, 2, 3]),
-		 custom_set:add(3, custom_set:from_list([1, 2, 3]))).
+    ?assert(custom_set:equal(custom_set:from_list([1, 2,
+						   3]),
+			     custom_set:add(3,
+					    custom_set:from_list([1, 2, 3])))).
 
 '26_intersection_of_two_empty_sets_is_an_empty_set_test'() ->
-    ?assertEqual(custom_set:from_list([]),
-		 custom_set:intersection(custom_set:from_list([]),
-					 custom_set:from_list([]))).
+    ?assert(custom_set:equal(custom_set:from_list([]),
+			     custom_set:intersection(custom_set:from_list([]),
+						     custom_set:from_list([])))).
 
 '27_intersection_of_an_empty_set_and_non_empty_set_is_an_empty_set_test'() ->
-    ?assertEqual(custom_set:from_list([]),
-		 custom_set:intersection(custom_set:from_list([]),
-					 custom_set:from_list([3, 2, 5]))).
+    ?assert(custom_set:equal(custom_set:from_list([]),
+			     custom_set:intersection(custom_set:from_list([]),
+						     custom_set:from_list([3, 2,
+									   5])))).
 
 '28_intersection_of_a_non_empty_set_and_an_empty_set_is_an_empty_set_test'() ->
-    ?assertEqual(custom_set:from_list([]),
-		 custom_set:intersection(custom_set:from_list([1, 2, 3,
-							       4]),
-					 custom_set:from_list([]))).
+    ?assert(custom_set:equal(custom_set:from_list([]),
+			     custom_set:intersection(custom_set:from_list([1, 2,
+									   3,
+									   4]),
+						     custom_set:from_list([])))).
 
 '29_intersection_of_two_sets_with_no_shared_elements_is_an_empty_set_test'() ->
-    ?assertEqual(custom_set:from_list([]),
-		 custom_set:intersection(custom_set:from_list([1, 2, 3]),
-					 custom_set:from_list([4, 5, 6]))).
+    ?assert(custom_set:equal(custom_set:from_list([]),
+			     custom_set:intersection(custom_set:from_list([1, 2,
+									   3]),
+						     custom_set:from_list([4, 5,
+									   6])))).
 
 '30_intersection_of_two_sets_with_shared_elements_is_a_set_of_the_shared_elements_test'() ->
-    ?assertEqual(custom_set:from_list([2, 3]),
-		 custom_set:intersection(custom_set:from_list([1, 2, 3,
-							       4]),
-					 custom_set:from_list([3, 2, 5]))).
+    ?assert(custom_set:equal(custom_set:from_list([2, 3]),
+			     custom_set:intersection(custom_set:from_list([1, 2,
+									   3,
+									   4]),
+						     custom_set:from_list([3, 2,
+									   5])))).
 
 '31_difference_of_two_empty_sets_is_an_empty_set_test'() ->
-    ?assertEqual(custom_set:from_list([]),
-		 custom_set:difference(custom_set:from_list([]),
-				       custom_set:from_list([]))).
+    ?assert(custom_set:equal(custom_set:from_list([]),
+			     custom_set:difference(custom_set:from_list([]),
+						   custom_set:from_list([])))).
 
 '32_difference_of_empty_set_and_non_empty_set_is_an_empty_set_test'() ->
-    ?assertEqual(custom_set:from_list([]),
-		 custom_set:difference(custom_set:from_list([]),
-				       custom_set:from_list([3, 2, 5]))).
+    ?assert(custom_set:equal(custom_set:from_list([]),
+			     custom_set:difference(custom_set:from_list([]),
+						   custom_set:from_list([3, 2,
+									 5])))).
 
 '33_difference_of_a_non_empty_set_and_an_empty_set_is_the_non_empty_set_test'() ->
-    ?assertEqual(custom_set:from_list([1, 2, 3, 4]),
-		 custom_set:difference(custom_set:from_list([1, 2, 3,
-							     4]),
-				       custom_set:from_list([]))).
+    ?assert(custom_set:equal(custom_set:from_list([1, 2, 3,
+						   4]),
+			     custom_set:difference(custom_set:from_list([1, 2,
+									 3, 4]),
+						   custom_set:from_list([])))).
 
 '34_difference_of_two_non_empty_sets_is_a_set_of_elements_that_are_only_in_the_first_set_test'() ->
-    ?assertEqual(custom_set:from_list([1, 3]),
-		 custom_set:difference(custom_set:from_list([3, 2, 1]),
-				       custom_set:from_list([2, 4]))).
+    ?assert(custom_set:equal(custom_set:from_list([1, 3]),
+			     custom_set:difference(custom_set:from_list([3, 2,
+									 1]),
+						   custom_set:from_list([2,
+									 4])))).
 
 '35_union_of_empty_sets_is_an_empty_set_test'() ->
-    ?assertEqual(custom_set:from_list([]),
-		 custom_set:union(custom_set:from_list([]),
-				  custom_set:from_list([]))).
+    ?assert(custom_set:equal(custom_set:from_list([]),
+			     custom_set:union(custom_set:from_list([]),
+					      custom_set:from_list([])))).
 
 '36_union_of_an_empty_set_and_non_empty_set_is_the_non_empty_set_test'() ->
-    ?assertEqual(custom_set:from_list([2]),
-		 custom_set:union(custom_set:from_list([]),
-				  custom_set:from_list([2]))).
+    ?assert(custom_set:equal(custom_set:from_list([2]),
+			     custom_set:union(custom_set:from_list([]),
+					      custom_set:from_list([2])))).
 
 '37_union_of_a_non_empty_set_and_empty_set_is_the_non_empty_set_test'() ->
-    ?assertEqual(custom_set:from_list([1, 3]),
-		 custom_set:union(custom_set:from_list([1, 3]),
-				  custom_set:from_list([]))).
+    ?assert(custom_set:equal(custom_set:from_list([1, 3]),
+			     custom_set:union(custom_set:from_list([1, 3]),
+					      custom_set:from_list([])))).
 
 '38_union_of_non_empty_sets_contains_all_unique_elements_test'() ->
-    ?assertEqual(custom_set:from_list([3, 2, 1]),
-		 custom_set:union(custom_set:from_list([1, 3]),
-				  custom_set:from_list([2, 3]))).
+    ?assert(custom_set:equal(custom_set:from_list([3, 2,
+						   1]),
+			     custom_set:union(custom_set:from_list([1, 3]),
+					      custom_set:from_list([2, 3])))).

--- a/testgen/src/tgen_custom-set.erl
+++ b/testgen/src/tgen_custom-set.erl
@@ -4,6 +4,7 @@
 
 -export([
     available/0,
+    prepare_tests/1,
     generate_test/2
 ]).
 
@@ -11,17 +12,29 @@
 available() ->
     true.
 
+prepare_tests(Cases) ->
+    %% pull up the equality tests because they are needed in other tests
+    {Equality, Other}=lists:partition(
+        fun
+            (#{property := <<"equal">>}) -> true;
+            (_) -> false
+        end,
+        Cases
+    ),
+    Equality++Other.
+
 generate_test(N, #{description := Desc, expected := Exp, property := Prop, input := #{set1 := Set1, set2 := Set2}}) when is_list(Exp) ->
     TestName = tgen:to_test_name(N, Desc),
     Property = tgen:to_property_name(Prop),
 
     Fn = tgs:simple_fun(TestName, [
-        tgs:call_macro("assertEqual", [
-            tgs:call_fun("custom_set:from_list", [
-                tgs:value(Exp)]),
-            tgs:call_fun("custom_set:" ++ Property, [
-                tgs:call_fun("custom_set:from_list", [tgs:value(Set1)]),
-                tgs:call_fun("custom_set:from_list", [tgs:value(Set2)])])])]),
+        tgs:call_macro("assert", [
+            tgs:call_fun("custom_set:equal", [
+                tgs:call_fun("custom_set:from_list", [
+                    tgs:value(Exp)]),
+                tgs:call_fun("custom_set:" ++ Property, [
+                    tgs:call_fun("custom_set:from_list", [tgs:value(Set1)]),
+                    tgs:call_fun("custom_set:from_list", [tgs:value(Set2)])])])])]),
 
     {ok, Fn, [{Property, ["Set1", "Set2"]}]};
 generate_test(N, #{description := Desc, expected := Exp, property := Prop, input := #{set1 := Set1, set2 := Set2}}) when Exp =:= true; Exp =:= false ->
@@ -45,13 +58,14 @@ generate_test(N, #{description := Desc, expected := Exp, property := Prop, input
     Property = tgen:to_property_name(Prop),
 
     Fn = tgs:simple_fun(TestName, [
-        tgs:call_macro("assertEqual", [
-            tgs:call_fun("custom_set:from_list", [
-                tgs:value(Exp)]),
-            tgs:call_fun("custom_set:" ++ Property, [
-                tgs:value(Elem),
+        tgs:call_macro("assert", [
+            tgs:call_fun("custom_set:equal", [
                 tgs:call_fun("custom_set:from_list", [
-                    erl_syntax:abstract(Set)])])])]),
+                    tgs:value(Exp)]),
+                tgs:call_fun("custom_set:" ++ Property, [
+                    tgs:value(Elem),
+                    tgs:call_fun("custom_set:from_list", [
+                        erl_syntax:abstract(Set)])])])])]),
 
     {ok, Fn, [{Property, ["Elem", "Set"]}, {"from_list", ["List"]}]};
 generate_test(N, #{description := Desc, expected := Exp, property := Prop, input := #{set := Set, element := Elem}}) when Exp =:= true; Exp =:= false ->


### PR DESCRIPTION
Replaces `?assertEqual` with `?assert(custom_set:equal(...` so sets that are equal even though their internal representations are different are accepted.

This PR also addresses version tracking in accordance with #278.