### PR TITLE
poker: test results independent of ordering

### DIFF
--- a/exercises/poker/test/poker_tests.erl
+++ b/exercises/poker/test/poker_tests.erl
@@ -5,7 +5,7 @@
 -include_lib("erl_exercism/include/exercism.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--define(test(X,Y), ?assertEqual(Y, poker:best(X))).
+-define(test(X,Y), ?assertEqual(lists:sort(Y), lists:sort(poker:best(X)))).
 
 single_hand_always_wins_test() ->
     ?test([


### PR DESCRIPTION
The ordering of the test results (ie, the winning hands) should not matter for the tests to pass.