### PR TITLE
accumulate: remove obsolte test versioning

### DIFF
--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -41,25 +41,6 @@ directory.
 $ rebar3 eunit
 ```
 
-### Test versioning
-
-Each problem defines a macro `TEST_VERSION` in the test file and
-verifies that the solution defines and exports a function `test_version`
-returning that same value.
-
-To make tests pass, add the following to your solution:
-
-```erlang
--export([test_version/0]).
-
-test_version() ->
-  1.
-```
-
-The benefit of this is that reviewers can see against which test version
-an iteration was written if, for example, a previously posted solution
-does not solve the current problem or passes current tests.
-
 ## Questions?
 
 For detailed information about the Erlang track, please refer to the

--- a/exercises/accumulate/src/accumulate.erl
+++ b/exercises/accumulate/src/accumulate.erl
@@ -1,8 +1,6 @@
 -module(accumulate).
 
--export([accumulate/2, test_version/0]).
+-export([accumulate/2]).
 
 accumulate(_Fn, _Ls) ->
   undefined.
-
-test_version() -> 1.

--- a/exercises/accumulate/src/example.erl
+++ b/exercises/accumulate/src/example.erl
@@ -1,5 +1,5 @@
 -module(example).
--export([accumulate/2, test_version/0]).
+-export([accumulate/2]).
 
 %%
 %% given a fun and a list, apply fun to each list item replacing list item with fun's return value.
@@ -9,6 +9,3 @@ accumulate(Fn, List)       -> accumulate(List, Fn, []).
 
 accumulate([H|T], Fn, Out) -> accumulate(T, Fn, [Fn(H) | Out]);
 accumulate([], _Fn, Out)   -> lists:reverse(Out).
-
-test_version() ->
-    1.

--- a/exercises/accumulate/test/accumulate_tests.erl
+++ b/exercises/accumulate/test/accumulate_tests.erl
@@ -23,6 +23,3 @@ accumulate_recursively_test() ->
   Nums = string:tokens("1 2 3", " "),
   Fn = fun(Char) -> [Char ++ Num || Num <- Nums] end,
   ?assertEqual([["a1", "a2", "a3"], ["b1", "b2", "b3"], ["c1", "c2", "c3"]], accumulate:accumulate(Fn, Chars)).
-
-version_test() ->
-  ?assertMatch(1, accumulate:test_version()).


### PR DESCRIPTION
This PR removes the obsolete test versioning from the accumulate exercise according to #278 .