### PR TITLE
strain: remove obsolete test versioning

### DIFF
--- a/exercises/strain/README.md
+++ b/exercises/strain/README.md
@@ -49,25 +49,6 @@ directory.
 $ rebar3 eunit
 ```
 
-### Test versioning
-
-Each problem defines a macro `TEST_VERSION` in the test file and
-verifies that the solution defines and exports a function `test_version`
-returning that same value.
-
-To make tests pass, add the following to your solution:
-
-```erlang
--export([test_version/0]).
-
-test_version() ->
-  1.
-```
-
-The benefit of this is that reviewers can see against which test version
-an iteration was written if, for example, a previously posted solution
-does not solve the current problem or passes current tests.
-
 ## Questions?
 
 For detailed information about the Erlang track, please refer to the

--- a/exercises/strain/src/example.erl
+++ b/exercises/strain/src/example.erl
@@ -1,6 +1,6 @@
 -module(example).
 
--export([keep/2, discard/2, test_version/0]).
+-export([keep/2, discard/2]).
 
 -spec keep(fun((any()) -> boolean()), list(any())) -> list(any()).
 keep(_F, []) ->
@@ -14,6 +14,3 @@ keep(F, [H|T]) ->
 -spec discard(fun((any()) -> boolean()), list(any())) -> list(any()).
 discard(F, L) ->
   keep(fun(X) -> not(F(X)) end, L).
-
-test_version() ->
-    1.

--- a/exercises/strain/src/strain.erl
+++ b/exercises/strain/src/strain.erl
@@ -1,11 +1,9 @@
 -module(strain).
 
--export([keep/2, discard/2, test_version/0]).
+-export([keep/2, discard/2]).
 
 keep(_Fn, _List) ->
   undefined.
 
 discard(_Fn, _List) ->
   undefined.
-
-test_version() -> 1.

--- a/exercises/strain/test/strain_tests.erl
+++ b/exercises/strain/test/strain_tests.erl
@@ -45,9 +45,6 @@ discard_strings_test() ->
      ["apple", "banana", "cherimoya"],
      strain:discard(fun(S) -> string:sub_string(S, 1,1) =:= "z" end, Str)).
 
-version_test() ->
-  ?assertMatch(1, strain:test_version()).
-
 odd(N) -> N rem 2 > 0.
 
 even(N) -> N rem 2 =:= 0.


### PR DESCRIPTION
this PR removes the obsolete test versioning from the `strain` exercise, according to #278 