### PR TITLE
bank-account: remove obsolete test versioning

### DIFF
--- a/exercises/bank-account/README.md
+++ b/exercises/bank-account/README.md
@@ -42,25 +42,6 @@ directory.
 $ rebar3 eunit
 ```
 
-### Test versioning
-
-Each problem defines a macro `TEST_VERSION` in the test file and
-verifies that the solution defines and exports a function `test_version`
-returning that same value.
-
-To make tests pass, add the following to your solution:
-
-```erlang
--export([test_version/0]).
-
-test_version() ->
-  1.
-```
-
-The benefit of this is that reviewers can see against which test version
-an iteration was written if, for example, a previously posted solution
-does not solve the current problem or passes current tests.
-
 ## Questions?
 
 For detailed information about the Erlang track, please refer to the

--- a/exercises/bank-account/src/bank_account.erl
+++ b/exercises/bank-account/src/bank_account.erl
@@ -1,6 +1,6 @@
 -module(bank_account).
 
--export([balance/1, charge/2, close/1, create/0, deposit/2, withdraw/2, test_version/0]).
+-export([balance/1, charge/2, close/1, create/0, deposit/2, withdraw/2]).
 
 balance(_Pid) ->
   undefined.
@@ -19,5 +19,3 @@ deposit(_Pid, _Amount) ->
 
 withdraw(_Pid, _Amount) ->
   undefined.
-
-test_version() -> 1.

--- a/exercises/bank-account/src/example.erl
+++ b/exercises/bank-account/src/example.erl
@@ -6,8 +6,7 @@
   close/1,
   create/0,
   deposit/2,
-  withdraw/2,
-  test_version/0
+  withdraw/2
 ]).
 
 -export([
@@ -23,9 +22,6 @@
 
 -record(account, {pid}).
 
-
-test_version() ->
-    1.
 
 
 %%% Public API

--- a/exercises/bank-account/test/bank_account_tests.erl
+++ b/exercises/bank-account/test/bank_account_tests.erl
@@ -88,6 +88,3 @@ charge_many_test() ->
   timer:sleep(100),
   Last = bank_account:balance(BankAccount),
   ?assert(Last =:= 5).
-
-version_test() ->
-  ?assertMatch(1, bank_account:test_version()).


### PR DESCRIPTION
this PR removes the obsolete test versioning from the `bank-account` exercise in accordance with #278