### PR TITLE
beer-song: remove obsolete test versioning

### DIFF
--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -336,25 +336,6 @@ directory.
 $ rebar3 eunit
 ```
 
-### Test versioning
-
-Each problem defines a macro `TEST_VERSION` in the test file and
-verifies that the solution defines and exports a function `test_version`
-returning that same value.
-
-To make tests pass, add the following to your solution:
-
-```erlang
--export([test_version/0]).
-
-test_version() ->
-  1.
-```
-
-The benefit of this is that reviewers can see against which test version
-an iteration was written if, for example, a previously posted solution
-does not solve the current problem or passes current tests.
-
 ## Questions?
 
 For detailed information about the Erlang track, please refer to the

--- a/exercises/beer-song/src/beer_song.erl
+++ b/exercises/beer-song/src/beer_song.erl
@@ -1,6 +1,6 @@
 -module(beer_song).
 
--export([verse/1, sing/1, sing/2, test_version/0]).
+-export([verse/1, sing/1, sing/2]).
 
 verse(_N) ->
   undefined.
@@ -10,5 +10,3 @@ sing(_N) ->
 
 sing(_From, _To) ->
   undefined.
-
-test_version() -> 1.

--- a/exercises/beer-song/src/example.erl
+++ b/exercises/beer-song/src/example.erl
@@ -1,6 +1,6 @@
 -module(example).
 
--export([verse/1, sing/1, sing/2, test_version/0]).
+-export([verse/1, sing/1, sing/2]).
 
 bottles(0) ->
   "no more bottles";
@@ -29,6 +29,3 @@ sing(N) ->
 -spec sing(non_neg_integer(), non_neg_integer()) -> iolist().
 sing(From, To) ->
   lists:map(fun (N) -> [verse(N), "\n"] end, lists:seq(From, To, -1)).
-
-test_version() ->
-    1.

--- a/exercises/beer-song/test/beer_song_tests.erl
+++ b/exercises/beer-song/test/beer_song_tests.erl
@@ -50,6 +50,3 @@ sing_all_the_rest_of_the_verses_test() ->
 
 compare_nested_lists(Response, Expected) ->
   ?assertEqual(lists:flatten(Expected), lists:flatten(Response)).
-
-version_test() ->
-  ?assertMatch(1, beer_song:test_version()).


### PR DESCRIPTION
this PR removes the obsolete test versioning from the `beer-song` exercise in accordance with #278