### PR TITLE
circular-buffer: remove obsolete test versioning

### DIFF
--- a/exercises/circular-buffer/README.md
+++ b/exercises/circular-buffer/README.md
@@ -66,25 +66,6 @@ directory.
 $ rebar3 eunit
 ```
 
-### Test versioning
-
-Each problem defines a macro `TEST_VERSION` in the test file and
-verifies that the solution defines and exports a function `test_version`
-returning that same value.
-
-To make tests pass, add the following to your solution:
-
-```erlang
--export([test_version/0]).
-
-test_version() ->
-  1.
-```
-
-The benefit of this is that reviewers can see against which test version
-an iteration was written if, for example, a previously posted solution
-does not solve the current problem or passes current tests.
-
 ## Questions?
 
 For detailed information about the Erlang track, please refer to the

--- a/exercises/circular-buffer/src/circular_buffer.erl
+++ b/exercises/circular-buffer/src/circular_buffer.erl
@@ -1,6 +1,6 @@
 -module(circular_buffer).
 
--export([create/1, read/1, size/1, write/2, write_attempt/2, test_version/0]).
+-export([create/1, read/1, size/1, write/2, write_attempt/2]).
 
 create(_Size) ->
   undefined.
@@ -16,5 +16,3 @@ write(_Pid, _Item) ->
 
 write_attempt(_Pid, _Item) ->
   undefined.
-
-test_version() -> 1.

--- a/exercises/circular-buffer/src/example.erl
+++ b/exercises/circular-buffer/src/example.erl
@@ -1,6 +1,6 @@
 -module(example).
 
--export( [create/1, read/1, size/1, write/2, write_attempt/2, test_version/0] ).
+-export( [create/1, read/1, size/1, write/2, write_attempt/2] ).
 
 create( Size ) -> erlang:spawn( fun() -> loop( 0, Size, queue:new() ) end ).
 
@@ -51,6 +51,3 @@ write( Max, Max, Item, Queue ) ->
 
 write_attempt( Max, Max, _Item, Queue ) -> {Max, Queue};
 write_attempt( Current, Max, Item, Queue ) -> write( Current, Max, Item, Queue ).
-
-test_version() ->
-    1.

--- a/exercises/circular-buffer/test/circular_buffer_tests.erl
+++ b/exercises/circular-buffer/test/circular_buffer_tests.erl
@@ -54,6 +54,3 @@ producer_consumer_test() ->
             {Ref, R} -> R
           end,
   ?assert( Reads =:= [{ok, 1}, {ok, 2}, {ok, 3}] ).
-
-version_test() ->
-  ?assertMatch(1, circular_buffer:test_version()).


### PR DESCRIPTION
this PR removes the obsolete test versioning from the `circular-buffer`exercise in accordance with #278