### PR TITLE
augment `var/1` for underscores

### DIFF
--- a/testgen/src/tgs.erl
+++ b/testgen/src/tgs.erl
@@ -90,5 +90,9 @@ raw(Text) when is_list(Text) ->
 value(Value) ->
     erl_syntax:abstract(Value).
 
+var("_") ->
+    erl_syntax:underscore();
+var(<<"_">>) ->
+    erl_syntax:underscore();
 var(Var) ->
     erl_syntax:variable(Var).


### PR DESCRIPTION
Underscores need to be handled differently with `erl_syntax` from normal variables.