### PR TITLE
zipper: remove obsolete test versioning

### DIFF
--- a/exercises/zipper/README.md
+++ b/exercises/zipper/README.md
@@ -43,25 +43,6 @@ directory.
 $ rebar3 eunit
 ```
 
-### Test versioning
-
-Each problem defines a macro `TEST_VERSION` in the test file and
-verifies that the solution defines and exports a function `test_version`
-returning that same value.
-
-To make tests pass, add the following to your solution:
-
-```erlang
--export([test_version/0]).
-
-test_version() ->
-  1.
-```
-
-The benefit of this is that reviewers can see against which test version
-an iteration was written if, for example, a previously posted solution
-does not solve the current problem or passes current tests.
-
 ## Questions?
 
 For detailed information about the Erlang track, please refer to the

--- a/exercises/zipper/src/example.erl
+++ b/exercises/zipper/src/example.erl
@@ -1,6 +1,6 @@
 -module(example).
 
--export([from_tree/1, to_tree/1, up/1, left/1, right/1, value/1, set_value/2, set_left/2, set_right/2, new_tree/3, test_version/0]).
+-export([from_tree/1, to_tree/1, up/1, left/1, right/1, value/1, set_value/2, set_left/2, set_right/2, new_tree/3]).
 
 -export_type([tree/0, zipper/0]).
 
@@ -23,9 +23,6 @@ new_tree(Value, Left, Right) ->
     #tree{value = Value,
           left  = Left,
           right = Right}.
-
-test_version() ->
-    1.
 
 %% Zipper API
 %% ==========

--- a/exercises/zipper/src/zipper.erl
+++ b/exercises/zipper/src/zipper.erl
@@ -1,6 +1,6 @@
 -module(zipper).
 
--export([new_tree/3, from_tree/1, to_tree/1, up/1, left/1, right/1, value/1, set_value/2, set_left/2, set_right/2, test_version/0]).
+-export([new_tree/3, from_tree/1, to_tree/1, up/1, left/1, right/1, value/1, set_value/2, set_left/2, set_right/2]).
 
 new_tree(_Value, _Left, _Right) ->
   undefined.
@@ -31,7 +31,3 @@ right(_Zipper) ->
 
 up(_Zipper) ->
   undefined.
-
-
-
-test_version() -> 1.

--- a/exercises/zipper/test/zipper_tests.erl
+++ b/exercises/zipper/test/zipper_tests.erl
@@ -96,6 +96,3 @@ set_value_from_deep_focus_test() ->
     Act3 = zipper:set_value(Act2, 5),
     Act4 = zipper:to_tree(Act3),
     ?assertMatch(Exp, Act4).
-
-version_test() ->
-  ?assertMatch(1, zipper:test_version()).


### PR DESCRIPTION
This is the last exercise on the track that used version tracking.