### PR TITLE
remove `sudo: false`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,3 @@ cache:
   - cache bundler
   - directories:
     - $HOME/bin
-
-sudo: false


### PR DESCRIPTION
That feature is deprecated according to:
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration