### PR TITLE
two-fer: make first effective core exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -20,6 +20,17 @@
       ]
     },
     {
+      "slug": "two-fer",
+      "uuid": "ea369b85-b180-48ca-b602-c40811fc865f",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "strings",
+        "arity"
+      ]
+    },
+    {
       "slug": "leap",
       "uuid": "241eb25c-925b-4395-876c-c1dfe84e1c85",
       "core": true,
@@ -343,16 +354,6 @@
       "difficulty": 3,
       "topics": [
         "pattern_matching",
-        "strings"
-      ]
-    },
-    {
-      "slug": "two-fer",
-      "uuid": "ea369b85-b180-48ca-b602-c40811fc865f",
-      "core": false,
-      "unlocked_by": "raindrops",
-      "difficulty": 3,
-      "topics": [
         "strings"
       ]
     },


### PR DESCRIPTION
This prepares the track to be able to participate in the auto-mentor project.

Not only that it makes the track to fulfill the requirement of having `two-fer` as effectively the first core exercise, but also it allows me to collect some more datapoints about how students might want to solve it.

@iHiD can we merge on own schedule or do we need to coordinate with you running THE script?