### PR TITLE
remove all references to 'test_version' from remaining exercises

### DIFF
--- a/exercises/nucleotide-count/src/example.erl
+++ b/exercises/nucleotide-count/src/example.erl
@@ -1,6 +1,6 @@
 -module(example).
 
--export([count/2, nucleotide_counts/1, validate/1, test_version/0]).
+-export([count/2, nucleotide_counts/1, validate/1]).
 
 count(Dna, N) ->
   validate(N),
@@ -27,6 +27,3 @@ nucleotide_counts(Dna) ->
    {"T", count(Dna, "T")},
    {"C", count(Dna, "C")},
    {"G", count(Dna, "G")}].
-
-test_version() ->
-    1.

--- a/exercises/phone-number/src/example.erl
+++ b/exercises/phone-number/src/example.erl
@@ -1,6 +1,6 @@
 -module(example).
 
--export([number/1, areacode/1, pretty_print/1, test_version/0]).
+-export([number/1, areacode/1, pretty_print/1]).
 
 -define(ZEROS, "0000000000").
 
@@ -33,6 +33,3 @@ areacode(String) ->
 pretty_print(String) ->
   {AreaCode, Exchange, Subscriber} = parts(String),
   lists:flatten(io_lib:format("\(~s\) ~s-~s", [AreaCode, Exchange, Subscriber])).
-
-test_version() ->
-    1.

--- a/exercises/phone-number/src/phone_number.erl
+++ b/exercises/phone-number/src/phone_number.erl
@@ -1,6 +1,6 @@
 -module(phone_number).
 
--export([number/1, areacode/1, pretty_print/1, test_version/0]).
+-export([number/1, areacode/1, pretty_print/1]).
 
 number(_String) ->
   undefined.
@@ -10,5 +10,3 @@ areacode(_String) ->
 
 pretty_print(_String) ->
   undefined.
-
-test_version() -> 1.

--- a/exercises/phone-number/test/phone_number_tests.erl
+++ b/exercises/phone-number/test/phone_number_tests.erl
@@ -24,6 +24,3 @@ area_code_test() ->
 pretty_print_test() ->
   ?assertEqual("(123) 456-7890", phone_number:pretty_print("1234567890")),
   ?assertEqual("(123) 456-7890", phone_number:pretty_print("11234567890")).
-
-version_test() ->
-  ?assertMatch(1, phone_number:test_version()).


### PR DESCRIPTION
FIX #278 