### PR TITLE
Add sshine as 'contributing maintainer'

### DIFF
--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -30,6 +30,16 @@
       "link_url": null,
       "avatar_url": null,
       "bio": "Found out about erlang via exercism, got hooked by its lightweight processes and how they are used as first class citizen. After fixing some trivial bugs in the track, I have been added to the team."
+    },
+    {
+      "github_username": "sshine",
+      "alumnus": false,
+      "show_on_website": false,
+      "name": "Simon Shine",
+      "link_text": "https://simonshine.dk/",
+      "link_url": "https://simonshine.dk/",
+      "avatar_url": null,
+      "bio": null
     }
   ]
 }


### PR DESCRIPTION
In response to #427, hereby adding myself as 'contributing maintainer' for the Erlang track. This entails `"show_on_website": false`. The context of a contributing maintainer is elaborated in a similar request
made on exercism/haskell#890. Reiterating the purpose:

> *[...]* We need people to do this as the team membership *[of the repo
> exercism/v3]* is based on this and we need people in the right teams
> for assigning to issues, and Code Owners *[in the exercism/v3 repo]*.