### PR TITLE
Add tests.toml file for grains exercise

### DIFF
--- a/exercises/grains/.meta/tests.toml
+++ b/exercises/grains/.meta/tests.toml
@@ -1,0 +1,34 @@
+[canonical-tests]
+
+# 1
+"9fbde8de-36b2-49de-baf2-cd42d6f28405" = true
+
+# 2
+"ee1f30c2-01d8-4298-b25d-c677331b5e6d" = true
+
+# 3
+"10f45584-2fc3-4875-8ec6-666065d1163b" = true
+
+# 4
+"a7cbe01b-36f4-4601-b053-c5f6ae055170" = true
+
+# 16
+"c50acc89-8535-44e4-918f-b848ad2817d4" = true
+
+# 32
+"acd81b46-c2ad-4951-b848-80d15ed5a04f" = true
+
+# 64
+"c73b470a-5efb-4d53-9ac6-c5f6487f227b" = true
+
+# square 0 raises an exception
+"1d47d832-3e85-4974-9466-5bd35af484e3" = true
+
+# negative square raises an exception
+"61974483-eeb2-465e-be54-ca5dde366453" = true
+
+# square greater than 64 raises an exception
+"a95e4374-f32c-45a7-a10d-ffec475c012f" = true
+
+# returns the total number of grains on the board
+"6eb07385-3659-4b45-a6be-9dc474222750" = true


### PR DESCRIPTION
Last week, we sent a PR in which tests.toml file were added for all exercises that have canonical data. Due to an issue, the grains exercise's tests.toml file was not included. This PR adds the tests.toml file for the grains exercise.