### PR TITLE
Remove travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
----
-language: erlang
-script:
-- printf "We are draining travis from this project, we will always pass. Please check GitHub actions when you want to add additional checks"

--- a/README.md
+++ b/README.md
@@ -86,5 +86,4 @@ Please make sure, that all tests pass by running
 `escript _test/check-exercises.escript`. Also a run of `bin/configlet lint`
 should pass without error message.
 
-Both programs will be run on Travis and a merge is unlikely if
-tests fail.
+Both programs will be run on CI and a merge is unlikely if tests fail.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ or `docs/INSTALLATION.md` in this repository. Also run
 `bin/fetch-configlet` to download the JSON-checker.
 
 Please make sure you use one of the releases of erlang/OTP as
-specified in `.travis.yml`, as these are the ones officially tested
-and supported by this track.
+specified in `.github/workflows/main.yml` (see the
+`jobs.test_erlang.strategy.matrix.otp` key), as these are the ones
+officially tested and supported by this track.
 
 Feel free to use any feature that was introduced in the oldest version
 of the range, while also avoiding everything that has been removed or


### PR DESCRIPTION
The track has been on GHA only for at least a year, though it kept some references to Travis-CI for legacy reasons.

This PR removes them.

Closes #435 