### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Erlang is a functional programming language, used for creating  real-time distributed systems, which can easily scale in size. 
 
 It's best for concurrent applications, such as instant messaging and banking platforms, as each function call has their own process and operates independently.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 If you have any trouble installing erlang please consider joining the 
 [gitter support channel](https://gitter.im/exercism/xerlang)
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -3,7 +3,7 @@
 If you have any trouble installing erlang please consider joining the 
 [gitter support channel](https://gitter.im/exercism/xerlang)
 
-### Homebrew for Mac OS X
+## Homebrew for Mac OS X
 
 Update your Homebrew to latest:
 
@@ -17,7 +17,7 @@ Install Erlang and Rebar3:
 $ brew install erlang rebar@3
 ```
 
-### On Linux
+## On Linux
 
 * Fedora 17+ and Fedora Rawhide: `sudo yum -y install erlang`
 * Arch Linux: `sudo pacman -S erlang`
@@ -36,7 +36,7 @@ via package manager are welcome).
 * Arch Linux: [install](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages)
   the AUR package [`rebar3`](https://aur.archlinux.org/packages/rebar3).
 
-### On Windows
+## On Windows
 
 Assuming [`choco`](https://chocolatey.org/) is available (maybe you
 already installed `exercism` CLI using it).
@@ -46,7 +46,7 @@ choco install erlang
 choco install rebar3
 ```
 
-### Installing from Source
+## Installing from Source
 
 Get [a recent Erlang OTP](http://www.erlang.org/download.html) and follow their
 [build-instructions](https://github.com/erlang/otp/blob/maint/HOWTO/INSTALL.md).

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 Exercism provides exercises and feedback but can be difficult to jump into for those learning Erlang for the first time. These resources can help you get started:
 
 * [Exercism related BEAM support channel on gitter](https://gitter.im/exercism/xerlang)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 ```bash
 $ rebar3 eunit
 ```

--- a/exercises/practice/complex-numbers/.docs/instructions.append.md
+++ b/exercises/practice/complex-numbers/.docs/instructions.append.md
@@ -1,2 +1,4 @@
+# Instructions append
+
 You also need to implement a `equal/2` function. For this you can consider
 two numbers as equal, when the difference of each component is less than 0.005.

--- a/exercises/practice/palindrome-products/HINTS.md
+++ b/exercises/practice/palindrome-products/HINTS.md
@@ -1,3 +1,5 @@
+# Hints
+
 A goal of this exercise is teaching you about efficiency. There are many ways
 to create a solution that produces correct results, but some solutions are more
 efficient and thereby finish faster than others.

--- a/exercises/practice/robot-simulator/.docs/instructions.append.md
+++ b/exercises/practice/robot-simulator/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 This exercise does require some kind of global state for your
 robot. In erlang this can be done in various ways (starting with most
 idiomatic one):

--- a/exercises/practice/zipper/hints/README.md
+++ b/exercises/practice/zipper/hints/README.md
@@ -1,2 +1,4 @@
+# Readme
+
 This directory contains some hints to help you complete this exercise. The
 higher the number of a hint file, the more explicit the hint.

--- a/exercises/practice/zipper/hints/hint_1.md
+++ b/exercises/practice/zipper/hints/hint_1.md
@@ -1,1 +1,3 @@
+# hint 1
+
 The difficult part is not getting there, but to remember how you got there.

--- a/exercises/practice/zipper/hints/hint_2.md
+++ b/exercises/practice/zipper/hints/hint_2.md
@@ -1,2 +1,4 @@
+# hint 2
+
 Keep a trail of what choices you mase. Be sure to include alternative branches,
 lest you forget them.

--- a/exercises/practice/zipper/hints/hint_3.md
+++ b/exercises/practice/zipper/hints/hint_3.md
@@ -1,3 +1,5 @@
+# hint 3
+
 ```erl
 -type trail :: {left,  any(), tree(), trail()}
              | {right, any(), tree(), trail()}


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
