### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,25 @@
+{
+  "docs": [
+    {
+      "uuid": "07a27deb-7c71-41f8-a0a8-fabe712bb83f",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Erlang locally",
+      "blurb": "Learn how to install Erlang locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "617d5683-a6d0-4ab6-a67d-541a6a0a039d",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Erlang",
+      "blurb": "An overview of how to get started from scratch with Erlang"
+    },
+    {
+      "uuid": "c668c236-71dc-4f76-9595-990ea2e9cd6e",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Erlang track",
+      "blurb": "Learn how to test your Erlang exercises on Exercism"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
