### PR TITLE
🤖 Sync exercise files keys based on file path patterns

### DIFF
--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/accumulate.erl"
+    ],
+    "test": [
+      "test/accumulate_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/all_your_base.erl"
+    ],
+    "test": [
+      "test/all_your_base_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/allergies.erl"
+    ],
+    "test": [
+      "test/allergies_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/anagram.erl"
+    ],
+    "test": [
+      "test/anagram_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Determine if a number is an Armstrong number",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/armstrong_numbers.erl"
+    ],
+    "test": [
+      "test/armstrong_numbers_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/atbash_cipher.erl"
+    ],
+    "test": [
+      "test/atbash_cipher_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/bank-account/.meta/config.json
+++ b/exercises/practice/bank-account/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Simulate a bank account supporting opening/closing, withdraws, and deposits of money. Watch out for concurrent transactions!",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/bank_account.erl"
+    ],
+    "test": [
+      "test/bank_account_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/beer_song.erl"
+    ],
+    "test": [
+      "test/beer_song_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/bob.erl"
+    ],
+    "test": [
+      "test/bob_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/book-store/.meta/config.json
+++ b/exercises/practice/book-store/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "To try and encourage more sales of different books from a popular 5 book series, a bookshop has decided to offer discounts of multiple-book purchases.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/book_store.erl"
+    ],
+    "test": [
+      "test/book_store_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/bracket-push/.meta/config.json
+++ b/exercises/practice/bracket-push/.meta/config.json
@@ -1,8 +1,12 @@
 {
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/bracket_push.erl"
+    ],
+    "test": [
+      "test/bracket_push_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Correctly determine change to be given using the least number of coins",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/change.erl"
+    ],
+    "test": [
+      "test/change_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "A data structure that uses a single, fixed-size buffer as if it were connected end-to-end.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/circular_buffer.erl"
+    ],
+    "test": [
+      "test/circular_buffer_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Implement a clock that handles times without dates.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/clock.erl"
+    ],
+    "test": [
+      "test/clock_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/collatz_conjecture.erl"
+    ],
+    "test": [
+      "test/collatz_conjecture_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/complex-numbers/.meta/config.json
+++ b/exercises/practice/complex-numbers/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Implement complex numbers.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/complex_numbers.erl"
+    ],
+    "test": [
+      "test/complex_numbers_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/connect/.meta/config.json
+++ b/exercises/practice/connect/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Compute the result for a game of Hex / Polygon",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/connect.erl"
+    ],
+    "test": [
+      "test/connect_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Implement the classic method for composing secret messages called a square code.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/crypto_square.erl"
+    ],
+    "test": [
+      "test/crypto_square_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Create a custom set type.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/custom_set.erl"
+    ],
+    "test": [
+      "test/custom_set_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Write a function that returns the earned points in a single toss of a Darts game",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/darts.erl"
+    ],
+    "test": [
+      "test/darts_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Given a letter, print a diamond starting with 'A' with the supplied letter at the widest point.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/diamond.erl"
+    ],
+    "test": [
+      "test/diamond_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/difference_of_squares.erl"
+    ],
+    "test": [
+      "test/difference_of_squares_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Make a chain of dominoes.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/dominoes.erl"
+    ],
+    "test": [
+      "test/dominoes_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/etl.erl"
+    ],
+    "test": [
+      "test/etl_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Implement an evaluator for a very simple subset of Forth",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/forth.erl"
+    ],
+    "test": [
+      "test/forth_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/gigasecond.erl"
+    ],
+    "test": [
+      "test/gigasecond_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Given students' names along with the grade that they are in, create a roster for the school",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/grade_school.erl"
+    ],
+    "test": [
+      "test/grade_school_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/grains.erl"
+    ],
+    "test": [
+      "test/grains_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Calculate the Hamming difference between two DNA strands.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/hamming.erl"
+    ],
+    "test": [
+      "test/hamming_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/hello_world.erl"
+    ],
+    "test": [
+      "test/hello_world_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Check if a given string is a valid ISBN-10 number.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/isbn_verifier.erl"
+    ],
+    "test": [
+      "test/isbn_verifier_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Determine if a word or phrase is an isogram.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/isogram.erl"
+    ],
+    "test": [
+      "test/isogram_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/largest_series_product.erl"
+    ],
+    "test": [
+      "test/largest_series_product_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Given a year, report if it is a leap year.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/leap.erl"
+    ],
+    "test": [
+      "test/leap_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Implement basic list operations",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/list_ops.erl"
+    ],
+    "test": [
+      "test/list_ops_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/luhn.erl"
+    ],
+    "test": [
+      "test/luhn_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Calculate the date of meetups.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/meetup.erl"
+    ],
+    "test": [
+      "test/meetup_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Add the numbers to a minesweeper board",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/minesweeper.erl"
+    ],
+    "test": [
+      "test/minesweeper_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Given a number n, determine what the nth prime is.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/nth_prime.erl"
+    ],
+    "test": [
+      "test/nth_prime_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/nucleotide_count.erl"
+    ],
+    "test": [
+      "test/nucleotide_count_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Detect palindrome products in a given range.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/palindrome_products.erl"
+    ],
+    "test": [
+      "test/palindrome_products_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Determine if a sentence is a pangram.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/pangram.erl"
+    ],
+    "test": [
+      "test/pangram_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/parallel-letter-frequency/.meta/config.json
+++ b/exercises/practice/parallel-letter-frequency/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Count the frequency of letters in texts using parallel computation.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/parallel_letter_frequency.erl"
+    ],
+    "test": [
+      "test/parallel_letter_frequency_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Compute Pascal's triangle up to a given number of rows.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/pascals_triangle.erl"
+    ],
+    "test": [
+      "test/pascals_triangle_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/perfect_numbers.erl"
+    ],
+    "test": [
+      "test/perfect_numbers_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/phone_number.erl"
+    ],
+    "test": [
+      "test/phone_number_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/poker/.meta/config.json
+++ b/exercises/practice/poker/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Pick the best hand(s) from a list of poker hands.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/poker.erl"
+    ],
+    "test": [
+      "test/poker_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Compute the prime factors of a given natural number.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/prime_factors.erl"
+    ],
+    "test": [
+      "test/prime_factors_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Translate RNA sequences into proteins.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/protein_translation.erl"
+    ],
+    "test": [
+      "test/protein_translation_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/pythagorean_triplet.erl"
+    ],
+    "test": [
+      "test/pythagorean_triplet_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/queen_attack.erl"
+    ],
+    "test": [
+      "test/queen_attack_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/rail-fence-cipher/.meta/config.json
+++ b/exercises/practice/rail-fence-cipher/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Implement encoding and decoding for the rail fence cipher.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/rail_fence_cipher.erl"
+    ],
+    "test": [
+      "test/rail_fence_cipher_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/raindrops.erl"
+    ],
+    "test": [
+      "test/raindrops_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/rational-numbers/.meta/config.json
+++ b/exercises/practice/rational-numbers/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Implement rational numbers.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/rational_numbers.erl"
+    ],
+    "test": [
+      "test/rational_numbers_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/rna_transcription.erl"
+    ],
+    "test": [
+      "test/rna_transcription_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Write a robot simulator.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/robot_simulator.erl"
+    ],
+    "test": [
+      "test/robot_simulator_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/roman_numerals.erl"
+    ],
+    "test": [
+      "test/roman_numerals_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/rotational-cipher/.meta/config.json
+++ b/exercises/practice/rotational-cipher/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/rotational_cipher.erl"
+    ],
+    "test": [
+      "test/rotational_cipher_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Implement run-length encoding and decoding.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/run_length_encoding.erl"
+    ],
+    "test": [
+      "test/run_length_encoding_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Detect saddle points in a matrix.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/saddle_points.erl"
+    ],
+    "test": [
+      "test/saddle_points_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/satellite/.meta/config.json
+++ b/exercises/practice/satellite/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Rebuild binary trees from pre-order and in-order traversals.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/satellite.erl"
+    ],
+    "test": [
+      "test/satellite_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Given a word, compute the Scrabble score for that word.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/scrabble_score.erl"
+    ],
+    "test": [
+      "test/scrabble_score_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/secret_handshake.erl"
+    ],
+    "test": [
+      "test/secret_handshake_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Given a string of digits, output all the contiguous substrings of length `n` in that string.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/series.erl"
+    ],
+    "test": [
+      "test/series_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/sieve.erl"
+    ],
+    "test": [
+      "test/sieve_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/simple-linked-list/.meta/config.json
+++ b/exercises/practice/simple-linked-list/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Write a simple linked list implementation that uses Elements and a List",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/simple_linked_list.erl"
+    ],
+    "test": [
+      "test/simple_linked_list_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/space_age.erl"
+    ],
+    "test": [
+      "test/space_age_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/spiral-matrix/.meta/config.json
+++ b/exercises/practice/spiral-matrix/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": " Given the size, return a square matrix of numbers in spiral order.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/spiral_matrix.erl"
+    ],
+    "test": [
+      "test/spiral_matrix_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/strain.erl"
+    ],
+    "test": [
+      "test/strain_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Write a function to determine if a list is a sublist of another list.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/sublist.erl"
+    ],
+    "test": [
+      "test/sublist_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/sum_of_multiples.erl"
+    ],
+    "test": [
+      "test/sum_of_multiples_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Take input text and output it transposed.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/transpose.erl"
+    ],
+    "test": [
+      "test/transpose_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/triangle.erl"
+    ],
+    "test": [
+      "test/triangle_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Create a sentence of the form \"One for X, one for me.\"",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/two_fer.erl"
+    ],
+    "test": [
+      "test/two_fer_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Implement variable length quantity encoding and decoding.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/variable_length_quantity.erl"
+    ],
+    "test": [
+      "test/variable_length_quantity_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/word_count.erl"
+    ],
+    "test": [
+      "test/word_count_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]

--- a/exercises/practice/zipper/.meta/config.json
+++ b/exercises/practice/zipper/.meta/config.json
@@ -2,8 +2,12 @@
   "blurb": "Creating a zipper for a binary tree.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/zipper.erl"
+    ],
+    "test": [
+      "test/zipper_tests.erl"
+    ],
     "example": [
       ".meta/example.erl"
     ]


### PR DESCRIPTION
To help tracks define the files in the exercise's `.meta/config.json` file, we've added support for defining these file patterns in the track's `config.json` file. See [this PR](https://github.com/exercism/docs/pull/58).

This PR updates the file paths defined in the `files` property of each exercise's `.meta/config.json` file according to the file patterns defined in the track's `config.json` file.

We only update a file path in the `.meta/config.json` file if:

- The file path pattern is a non-empty array in the `config.json` file
- The file path pattern is either not set or an empty array in the `.meta/config.json` file

This means that exercises that had already defined files in the `.meta/config.json` won't be touched in this PR.

Note that this PR is just an easy way for tracks to populate the files in the `.meta/config.json` files. Tracks are completely free to add/change/remove the files in their `.meta/config.json` files.

In the future, we'll update `configlet` to include this functionality. If you'd like me to re-run the script because changes have been made, feel free to ping me on Slack (@erikschierboom).

## Tracking

https://github.com/exercism/v3-launch/issues/20

