### PR TITLE
🤖 Simplify tests.toml files

### DIFF
--- a/exercises/practice/all-your-base/.meta/tests.toml
+++ b/exercises/practice/all-your-base/.meta/tests.toml
@@ -4,84 +4,63 @@
 
 [5ce422f9-7a4b-4f44-ad29-49c67cb32d2c]
 description = "single bit one to decimal"
-include = true
 
 [0cc3fea8-bb79-46ac-a2ab-5a2c93051033]
 description = "binary to single decimal"
-include = true
 
 [f12db0f9-0d3d-42c2-b3ba-e38cb375a2b8]
 description = "single decimal to binary"
-include = true
 
 [2c45cf54-6da3-4748-9733-5a3c765d925b]
 description = "binary to multiple decimal"
-include = true
 
 [65ddb8b4-8899-4fcc-8618-181b2cf0002d]
 description = "decimal to binary"
-include = true
 
 [8d418419-02a7-4824-8b7a-352d33c6987e]
 description = "trinary to hexadecimal"
-include = true
 
 [d3901c80-8190-41b9-bd86-38d988efa956]
 description = "hexadecimal to trinary"
-include = true
 
 [5d42f85e-21ad-41bd-b9be-a3e8e4258bbf]
 description = "15-bit integer"
-include = true
 
 [d68788f7-66dd-43f8-a543-f15b6d233f83]
 description = "empty list"
-include = true
 
 [5e27e8da-5862-4c5f-b2a9-26c0382b6be7]
 description = "single zero"
-include = true
 
 [2e1c2573-77e4-4b9c-8517-6c56c5bcfdf2]
 description = "multiple zeros"
-include = true
 
 [3530cd9f-8d6d-43f5-bc6e-b30b1db9629b]
 description = "leading zeros"
-include = true
 
 [a6b476a1-1901-4f2a-92c4-4d91917ae023]
 description = "input base is one"
-include = true
 
 [e21a693a-7a69-450b-b393-27415c26a016]
 description = "input base is zero"
-include = true
 
 [54a23be5-d99e-41cc-88e0-a650ffe5fcc2]
 description = "input base is negative"
-include = true
 
 [9eccf60c-dcc9-407b-95d8-c37b8be56bb6]
 description = "negative digit"
-include = true
 
 [232fa4a5-e761-4939-ba0c-ed046cd0676a]
 description = "invalid positive digit"
-include = true
 
 [14238f95-45da-41dc-95ce-18f860b30ad3]
 description = "output base is one"
-include = true
 
 [73dac367-da5c-4a37-95fe-c87fad0a4047]
 description = "output base is zero"
-include = true
 
 [13f81f42-ff53-4e24-89d9-37603a48ebd9]
 description = "output base is negative"
-include = true
 
 [0e6c895d-8a5d-4868-a345-309d094cfe8d]
 description = "both bases are negative"
-include = true

--- a/exercises/practice/allergies/.meta/tests.toml
+++ b/exercises/practice/allergies/.meta/tests.toml
@@ -4,196 +4,147 @@
 
 [17fc7296-2440-4ac4-ad7b-d07c321bc5a0]
 description = "not allergic to anything"
-include = true
 
 [07ced27b-1da5-4c2e-8ae2-cb2791437546]
 description = "allergic only to eggs"
-include = true
 
 [5035b954-b6fa-4b9b-a487-dae69d8c5f96]
 description = "allergic to eggs and something else"
-include = true
 
 [64a6a83a-5723-4b5b-a896-663307403310]
 description = "allergic to something, but not eggs"
-include = true
 
 [90c8f484-456b-41c4-82ba-2d08d93231c6]
 description = "allergic to everything"
-include = true
 
 [d266a59a-fccc-413b-ac53-d57cb1f0db9d]
 description = "not allergic to anything"
-include = true
 
 [ea210a98-860d-46b2-a5bf-50d8995b3f2a]
 description = "allergic only to peanuts"
-include = true
 
 [eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b]
 description = "allergic to peanuts and something else"
-include = true
 
 [9152058c-ce39-4b16-9b1d-283ec6d25085]
 description = "allergic to something, but not peanuts"
-include = true
 
 [d2d71fd8-63d5-40f9-a627-fbdaf88caeab]
 description = "allergic to everything"
-include = true
 
 [b948b0a1-cbf7-4b28-a244-73ff56687c80]
 description = "not allergic to anything"
-include = true
 
 [9ce9a6f3-53e9-4923-85e0-73019047c567]
 description = "allergic only to shellfish"
-include = true
 
 [b272fca5-57ba-4b00-bd0c-43a737ab2131]
 description = "allergic to shellfish and something else"
-include = true
 
 [21ef8e17-c227-494e-8e78-470a1c59c3d8]
 description = "allergic to something, but not shellfish"
-include = true
 
 [cc789c19-2b5e-4c67-b146-625dc8cfa34e]
 description = "allergic to everything"
-include = true
 
 [651bde0a-2a74-46c4-ab55-02a0906ca2f5]
 description = "not allergic to anything"
-include = true
 
 [b649a750-9703-4f5f-b7f7-91da2c160ece]
 description = "allergic only to strawberries"
-include = true
 
 [50f5f8f3-3bac-47e6-8dba-2d94470a4bc6]
 description = "allergic to strawberries and something else"
-include = true
 
 [23dd6952-88c9-48d7-a7d5-5d0343deb18d]
 description = "allergic to something, but not strawberries"
-include = true
 
 [74afaae2-13b6-43a2-837a-286cd42e7d7e]
 description = "allergic to everything"
-include = true
 
 [c49a91ef-6252-415e-907e-a9d26ef61723]
 description = "not allergic to anything"
-include = true
 
 [b69c5131-b7d0-41ad-a32c-e1b2cc632df8]
 description = "allergic only to tomatoes"
-include = true
 
 [1ca50eb1-f042-4ccf-9050-341521b929ec]
 description = "allergic to tomatoes and something else"
-include = true
 
 [e9846baa-456b-4eff-8025-034b9f77bd8e]
 description = "allergic to something, but not tomatoes"
-include = true
 
 [b2414f01-f3ad-4965-8391-e65f54dad35f]
 description = "allergic to everything"
-include = true
 
 [978467ab-bda4-49f7-b004-1d011ead947c]
 description = "not allergic to anything"
-include = true
 
 [59cf4e49-06ea-4139-a2c1-d7aad28f8cbc]
 description = "allergic only to chocolate"
-include = true
 
 [b0a7c07b-2db7-4f73-a180-565e07040ef1]
 description = "allergic to chocolate and something else"
-include = true
 
 [f5506893-f1ae-482a-b516-7532ba5ca9d2]
 description = "allergic to something, but not chocolate"
-include = true
 
 [02debb3d-d7e2-4376-a26b-3c974b6595c6]
 description = "allergic to everything"
-include = true
 
 [17f4a42b-c91e-41b8-8a76-4797886c2d96]
 description = "not allergic to anything"
-include = true
 
 [7696eba7-1837-4488-882a-14b7b4e3e399]
 description = "allergic only to pollen"
-include = true
 
 [9a49aec5-fa1f-405d-889e-4dfc420db2b6]
 description = "allergic to pollen and something else"
-include = true
 
 [3cb8e79f-d108-4712-b620-aa146b1954a9]
 description = "allergic to something, but not pollen"
-include = true
 
 [1dc3fe57-7c68-4043-9d51-5457128744b2]
 description = "allergic to everything"
-include = true
 
 [d3f523d6-3d50-419b-a222-d4dfd62ce314]
 description = "not allergic to anything"
-include = true
 
 [eba541c3-c886-42d3-baef-c048cb7fcd8f]
 description = "allergic only to cats"
-include = true
 
 [ba718376-26e0-40b7-bbbe-060287637ea5]
 description = "allergic to cats and something else"
-include = true
 
 [3c6dbf4a-5277-436f-8b88-15a206f2d6c4]
 description = "allergic to something, but not cats"
-include = true
 
 [1faabb05-2b98-4995-9046-d83e4a48a7c1]
 description = "allergic to everything"
-include = true
 
 [f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f]
 description = "no allergies"
-include = true
 
 [9e1a4364-09a6-4d94-990f-541a94a4c1e8]
 description = "just eggs"
-include = true
 
 [8851c973-805e-4283-9e01-d0c0da0e4695]
 description = "just peanuts"
-include = true
 
 [2c8943cb-005e-435f-ae11-3e8fb558ea98]
 description = "just strawberries"
-include = true
 
 [6fa95d26-044c-48a9-8a7b-9ee46ec32c5c]
 description = "eggs and peanuts"
-include = true
 
 [19890e22-f63f-4c5c-a9fb-fb6eacddfe8e]
 description = "more than eggs but not peanuts"
-include = true
 
 [4b68f470-067c-44e4-889f-c9fe28917d2f]
 description = "lots of stuff"
-include = true
 
 [0881b7c5-9efa-4530-91bd-68370d054bc7]
 description = "everything"
-include = true
 
 [12ce86de-b347-42a0-ab7c-2e0570f0c65b]
 description = "no allergen score parts"
-include = true

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -4,56 +4,42 @@
 
 [dd40c4d2-3c8b-44e5-992a-f42b393ec373]
 description = "no matches"
-include = true
 
 [b3cca662-f50a-489e-ae10-ab8290a09bdc]
 description = "detects two anagrams"
-include = true
 
 [a27558ee-9ba0-4552-96b1-ecf665b06556]
 description = "does not detect anagram subsets"
-include = true
 
 [64cd4584-fc15-4781-b633-3d814c4941a4]
 description = "detects anagram"
-include = true
 
 [99c91beb-838f-4ccd-b123-935139917283]
 description = "detects three anagrams"
-include = true
 
 [78487770-e258-4e1f-a646-8ece10950d90]
 description = "detects multiple anagrams with different case"
-include = true
 
 [1d0ab8aa-362f-49b7-9902-3d0c668d557b]
 description = "does not detect non-anagrams with identical checksum"
-include = true
 
 [9e632c0b-c0b1-4804-8cc1-e295dea6d8a8]
 description = "detects anagrams case-insensitively"
-include = true
 
 [b248e49f-0905-48d2-9c8d-bd02d8c3e392]
 description = "detects anagrams using case-insensitive subject"
-include = true
 
 [f367325c-78ec-411c-be76-e79047f4bd54]
 description = "detects anagrams using case-insensitive possible matches"
-include = true
 
 [7cc195ad-e3c7-44ee-9fd2-d3c344806a2c]
 description = "does not detect an anagram if the original word is repeated"
-include = true
 
 [9878a1c9-d6ea-4235-ae51-3ea2befd6842]
 description = "anagrams must use all letters exactly once"
-include = true
 
 [85757361-4535-45fd-ac0e-3810d40debc1]
 description = "words are not anagrams of themselves (case-insensitive)"
-include = true
 
 [a0705568-628c-4b55-9798-82e4acde51ca]
 description = "words other than themselves can be anagrams"
-include = true

--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -4,36 +4,27 @@
 
 [c1ed103c-258d-45b2-be73-d8c6d9580c7b]
 description = "Zero is an Armstrong number"
-include = true
 
 [579e8f03-9659-4b85-a1a2-d64350f6b17a]
 description = "Single digit numbers are Armstrong numbers"
-include = true
 
 [2d6db9dc-5bf8-4976-a90b-b2c2b9feba60]
 description = "There are no 2 digit Armstrong numbers"
-include = true
 
 [509c087f-e327-4113-a7d2-26a4e9d18283]
 description = "Three digit number that is an Armstrong number"
-include = true
 
 [7154547d-c2ce-468d-b214-4cb953b870cf]
 description = "Three digit number that is not an Armstrong number"
-include = true
 
 [6bac5b7b-42e9-4ecb-a8b0-4832229aa103]
 description = "Four digit number that is an Armstrong number"
-include = true
 
 [eed4b331-af80-45b5-a80b-19c9ea444b2e]
 description = "Four digit number that is not an Armstrong number"
-include = true
 
 [f971ced7-8d68-4758-aea1-d4194900b864]
 description = "Seven digit number that is an Armstrong number"
-include = true
 
 [7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18]
 description = "Seven digit number that is not an Armstrong number"
-include = true

--- a/exercises/practice/atbash-cipher/.meta/tests.toml
+++ b/exercises/practice/atbash-cipher/.meta/tests.toml
@@ -4,56 +4,42 @@
 
 [2f47ebe1-eab9-4d6b-b3c6-627562a31c77]
 description = "encode yes"
-include = true
 
 [b4ffe781-ea81-4b74-b268-cc58ba21c739]
 description = "encode no"
-include = true
 
 [10e48927-24ab-4c4d-9d3f-3067724ace00]
 description = "encode OMG"
-include = true
 
 [d59b8bc3-509a-4a9a-834c-6f501b98750b]
 description = "encode spaces"
-include = true
 
 [31d44b11-81b7-4a94-8b43-4af6a2449429]
 description = "encode mindblowingly"
-include = true
 
 [d503361a-1433-48c0-aae0-d41b5baa33ff]
 description = "encode numbers"
-include = true
 
 [79c8a2d5-0772-42d4-b41b-531d0b5da926]
 description = "encode deep thought"
-include = true
 
 [9ca13d23-d32a-4967-a1fd-6100b8742bab]
 description = "encode all the letters"
-include = true
 
 [bb50e087-7fdf-48e7-9223-284fe7e69851]
 description = "decode exercism"
-include = true
 
 [ac021097-cd5d-4717-8907-b0814b9e292c]
 description = "decode a sentence"
-include = true
 
 [18729de3-de74-49b8-b68c-025eaf77f851]
 description = "decode numbers"
-include = true
 
 [0f30325f-f53b-415d-ad3e-a7a4f63de034]
 description = "decode all the letters"
-include = true
 
 [39640287-30c6-4c8c-9bac-9d613d1a5674]
 description = "decode with too many spaces"
-include = true
 
 [b34edf13-34c0-49b5-aa21-0768928000d5]
 description = "decode with no spaces"
-include = true

--- a/exercises/practice/bob/.meta/tests.toml
+++ b/exercises/practice/bob/.meta/tests.toml
@@ -4,100 +4,75 @@
 
 [e162fead-606f-437a-a166-d051915cea8e]
 description = "stating something"
-include = true
 
 [73a966dc-8017-47d6-bb32-cf07d1a5fcd9]
 description = "shouting"
-include = true
 
 [d6c98afd-df35-4806-b55e-2c457c3ab748]
 description = "shouting gibberish"
-include = true
 
 [8a2e771d-d6f1-4e3f-b6c6-b41495556e37]
 description = "asking a question"
-include = true
 
 [81080c62-4e4d-4066-b30a-48d8d76920d9]
 description = "asking a numeric question"
-include = true
 
 [2a02716d-685b-4e2e-a804-2adaf281c01e]
 description = "asking gibberish"
-include = true
 
 [c02f9179-ab16-4aa7-a8dc-940145c385f7]
 description = "talking forcefully"
-include = true
 
 [153c0e25-9bb5-4ec5-966e-598463658bcd]
 description = "using acronyms in regular speech"
-include = true
 
 [a5193c61-4a92-4f68-93e2-f554eb385ec6]
 description = "forceful question"
-include = true
 
 [a20e0c54-2224-4dde-8b10-bd2cdd4f61bc]
 description = "shouting numbers"
-include = true
 
 [f7bc4b92-bdff-421e-a238-ae97f230ccac]
 description = "no letters"
-include = true
 
 [bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2]
 description = "question with no letters"
-include = true
 
 [496143c8-1c31-4c01-8a08-88427af85c66]
 description = "shouting with special characters"
-include = true
 
 [e6793c1c-43bd-4b8d-bc11-499aea73925f]
 description = "shouting with no exclamation mark"
-include = true
 
 [aa8097cc-c548-4951-8856-14a404dd236a]
 description = "statement containing question mark"
-include = true
 
 [9bfc677d-ea3a-45f2-be44-35bc8fa3753e]
 description = "non-letters with question"
-include = true
 
 [8608c508-f7de-4b17-985b-811878b3cf45]
 description = "prattling on"
-include = true
 
 [bc39f7c6-f543-41be-9a43-fd1c2f753fc0]
 description = "silence"
-include = true
 
 [d6c47565-372b-4b09-b1dd-c40552b8378b]
 description = "prolonged silence"
-include = true
 
 [4428f28d-4100-4d85-a902-e5a78cb0ecd3]
 description = "alternate silence"
-include = true
 
 [66953780-165b-4e7e-8ce3-4bcb80b6385a]
 description = "multiple line question"
-include = true
 
 [5371ef75-d9ea-4103-bcfa-2da973ddec1b]
 description = "starting with whitespace"
-include = true
 
 [05b304d6-f83b-46e7-81e0-4cd3ca647900]
 description = "ending with whitespace"
-include = true
 
 [72bd5ad3-9b2f-4931-a988-dce1f5771de2]
 description = "other whitespace"
-include = true
 
 [12983553-8601-46a8-92fa-fcaa3bc4a2a0]
 description = "non-question ending with whitespace"
-include = true

--- a/exercises/practice/book-store/.meta/tests.toml
+++ b/exercises/practice/book-store/.meta/tests.toml
@@ -4,60 +4,45 @@
 
 [17146bd5-2e80-4557-ab4c-05632b6b0d01]
 description = "Only a single book"
-include = true
 
 [cc2de9ac-ff2a-4efd-b7c7-bfe0f43271ce]
 description = "Two of the same book"
-include = true
 
 [5a86eac0-45d2-46aa-bbf0-266b94393a1a]
 description = "Empty basket"
-include = true
 
 [158bd19a-3db4-4468-ae85-e0638a688990]
 description = "Two different books"
-include = true
 
 [f3833f6b-9332-4a1f-ad98-6c3f8e30e163]
 description = "Three different books"
-include = true
 
 [1951a1db-2fb6-4cd1-a69a-f691b6dd30a2]
 description = "Four different books"
-include = true
 
 [d70f6682-3019-4c3f-aede-83c6a8c647a3]
 description = "Five different books"
-include = true
 
 [78cacb57-911a-45f1-be52-2a5bd428c634]
 description = "Two groups of four is cheaper than group of five plus group of three"
-include = true
 
 [f808b5a4-e01f-4c0d-881f-f7b90d9739da]
 description = "Two groups of four is cheaper than groups of five and three"
-include = true
 
 [fe96401c-5268-4be2-9d9e-19b76478007c]
 description = "Group of four plus group of two is cheaper than two groups of three"
-include = true
 
 [68ea9b78-10ad-420e-a766-836a501d3633]
 description = "Two each of first 4 books and 1 copy each of rest"
-include = true
 
 [c0a779d5-a40c-47ae-9828-a340e936b866]
 description = "Two copies of each book"
-include = true
 
 [18fd86fe-08f1-4b68-969b-392b8af20513]
 description = "Three copies of first book and 2 each of remaining"
-include = true
 
 [0b19a24d-e4cf-4ec8-9db2-8899a41af0da]
 description = "Three each of first 2 books and 2 each of remaining books"
-include = true
 
 [bb376344-4fb2-49ab-ab85-e38d8354a58d]
 description = "Four groups of four are cheaper than two groups each of five and three"
-include = true

--- a/exercises/practice/change/.meta/tests.toml
+++ b/exercises/practice/change/.meta/tests.toml
@@ -4,48 +4,36 @@
 
 [d0ebd0e1-9d27-4609-a654-df5c0ba1d83a]
 description = "change for 1 cent"
-include = true
 
 [36887bea-7f92-4a9c-b0cc-c0e886b3ecc8]
 description = "single coin change"
-include = true
 
 [cef21ccc-0811-4e6e-af44-f011e7eab6c6]
 description = "multiple coin change"
-include = true
 
 [d60952bc-0c1a-4571-bf0c-41be72690cb3]
 description = "change with Lilliputian Coins"
-include = true
 
 [408390b9-fafa-4bb9-b608-ffe6036edb6c]
 description = "change with Lower Elbonia Coins"
-include = true
 
 [7421a4cb-1c48-4bf9-99c7-7f049689132f]
 description = "large target values"
-include = true
 
 [f79d2e9b-0ae3-4d6a-bb58-dc978b0dba28]
 description = "possible change without unit coins available"
-include = true
 
 [9a166411-d35d-4f7f-a007-6724ac266178]
 description = "another possible change without unit coins available"
-include = true
 
 [bbbcc154-e9e9-4209-a4db-dd6d81ec26bb]
 description = "no coins make 0 change"
-include = true
 
 [c8b81d5a-49bd-4b61-af73-8ee5383a2ce1]
 description = "error testing for change smaller than the smallest of coins"
-include = true
 
 [3c43e3e4-63f9-46ac-9476-a67516e98f68]
 description = "error if no combination can add up to target"
-include = true
 
 [8fe1f076-9b2d-4f44-89fe-8a6ccd63c8f3]
 description = "cannot find negative change values"
-include = true

--- a/exercises/practice/clock/.meta/tests.toml
+++ b/exercises/practice/clock/.meta/tests.toml
@@ -4,208 +4,156 @@
 
 [a577bacc-106b-496e-9792-b3083ea8705e]
 description = "on the hour"
-include = true
 
 [b5d0c360-3b88-489b-8e84-68a1c7a4fa23]
 description = "past the hour"
-include = true
 
 [473223f4-65f3-46ff-a9f7-7663c7e59440]
 description = "midnight is zero hours"
-include = true
 
 [ca95d24a-5924-447d-9a96-b91c8334725c]
 description = "hour rolls over"
-include = true
 
 [f3826de0-0925-4d69-8ac8-89aea7e52b78]
 description = "hour rolls over continuously"
-include = true
 
 [a02f7edf-dfd4-4b11-b21a-86de3cc6a95c]
 description = "sixty minutes is next hour"
-include = true
 
 [8f520df6-b816-444d-b90f-8a477789beb5]
 description = "minutes roll over"
-include = true
 
 [c75c091b-47ac-4655-8d40-643767fc4eed]
 description = "minutes roll over continuously"
-include = true
 
 [06343ecb-cf39-419d-a3f5-dcbae0cc4c57]
 description = "hour and minutes roll over"
-include = true
 
 [be60810e-f5d9-4b58-9351-a9d1e90e660c]
 description = "hour and minutes roll over continuously"
-include = true
 
 [1689107b-0b5c-4bea-aad3-65ec9859368a]
 description = "hour and minutes roll over to exactly midnight"
-include = true
 
 [d3088ee8-91b7-4446-9e9d-5e2ad6219d91]
 description = "negative hour"
-include = true
 
 [77ef6921-f120-4d29-bade-80d54aa43b54]
 description = "negative hour rolls over"
-include = true
 
 [359294b5-972f-4546-bb9a-a85559065234]
 description = "negative hour rolls over continuously"
-include = true
 
 [509db8b7-ac19-47cc-bd3a-a9d2f30b03c0]
 description = "negative minutes"
-include = true
 
 [5d6bb225-130f-4084-84fd-9e0df8996f2a]
 description = "negative minutes roll over"
-include = true
 
 [d483ceef-b520-4f0c-b94a-8d2d58cf0484]
 description = "negative minutes roll over continuously"
-include = true
 
 [1cd19447-19c6-44bf-9d04-9f8305ccb9ea]
 description = "negative sixty minutes is previous hour"
-include = true
 
 [9d3053aa-4f47-4afc-bd45-d67a72cef4dc]
 description = "negative hour and minutes both roll over"
-include = true
 
 [51d41fcf-491e-4ca0-9cae-2aa4f0163ad4]
 description = "negative hour and minutes both roll over continuously"
-include = true
 
 [d098e723-ad29-4ef9-997a-2693c4c9d89a]
 description = "add minutes"
-include = true
 
 [b6ec8f38-e53e-4b22-92a7-60dab1f485f4]
 description = "add no minutes"
-include = true
 
 [efd349dd-0785-453e-9ff8-d7452a8e7269]
 description = "add to next hour"
-include = true
 
 [749890f7-aba9-4702-acce-87becf4ef9fe]
 description = "add more than one hour"
-include = true
 
 [da63e4c1-1584-46e3-8d18-c9dc802c1713]
 description = "add more than two hours with carry"
-include = true
 
 [be167a32-3d33-4cec-a8bc-accd47ddbb71]
 description = "add across midnight"
-include = true
 
 [6672541e-cdae-46e4-8be7-a820cc3be2a8]
 description = "add more than one day (1500 min = 25 hrs)"
-include = true
 
 [1918050d-c79b-4cb7-b707-b607e2745c7e]
 description = "add more than two days"
-include = true
 
 [37336cac-5ede-43a5-9026-d426cbe40354]
 description = "subtract minutes"
-include = true
 
 [0aafa4d0-3b5f-4b12-b3af-e3a9e09c047b]
 description = "subtract to previous hour"
-include = true
 
 [9b4e809c-612f-4b15-aae0-1df0acb801b9]
 description = "subtract more than an hour"
-include = true
 
 [8b04bb6a-3d33-4e6c-8de9-f5de6d2c70d6]
 description = "subtract across midnight"
-include = true
 
 [07c3bbf7-ce4d-4658-86e8-4a77b7a5ccd9]
 description = "subtract more than two hours"
-include = true
 
 [90ac8a1b-761c-4342-9c9c-cdc3ed5db097]
 description = "subtract more than two hours with borrow"
-include = true
 
 [2149f985-7136-44ad-9b29-ec023a97a2b7]
 description = "subtract more than one day (1500 min = 25 hrs)"
-include = true
 
 [ba11dbf0-ac27-4acb-ada9-3b853ec08c97]
 description = "subtract more than two days"
-include = true
 
 [f2fdad51-499f-4c9b-a791-b28c9282e311]
 description = "clocks with same time"
-include = true
 
 [5d409d4b-f862-4960-901e-ec430160b768]
 description = "clocks a minute apart"
-include = true
 
 [a6045fcf-2b52-4a47-8bb2-ef10a064cba5]
 description = "clocks an hour apart"
-include = true
 
 [66b12758-0be5-448b-a13c-6a44bce83527]
 description = "clocks with hour overflow"
-include = true
 
 [2b19960c-212e-4a71-9aac-c581592f8111]
 description = "clocks with hour overflow by several days"
-include = true
 
 [6f8c6541-afac-4a92-b0c2-b10d4e50269f]
 description = "clocks with negative hour"
-include = true
 
 [bb9d5a68-e324-4bf5-a75e-0e9b1f97a90d]
 description = "clocks with negative hour that wraps"
-include = true
 
 [56c0326d-565b-4d19-a26f-63b3205778b7]
 description = "clocks with negative hour that wraps multiple times"
-include = true
 
 [c90b9de8-ddff-4ffe-9858-da44a40fdbc2]
 description = "clocks with minute overflow"
-include = true
 
 [533a3dc5-59a7-491b-b728-a7a34fe325de]
 description = "clocks with minute overflow by several days"
-include = true
 
 [fff49e15-f7b7-4692-a204-0f6052d62636]
 description = "clocks with negative minute"
-include = true
 
 [605c65bb-21bd-43eb-8f04-878edf508366]
 description = "clocks with negative minute that wraps"
-include = true
 
 [b87e64ed-212a-4335-91fd-56da8421d077]
 description = "clocks with negative minute that wraps multiple times"
-include = true
 
 [822fbf26-1f3b-4b13-b9bf-c914816b53dd]
 description = "clocks with negative hours and minutes"
-include = true
 
 [e787bccd-cf58-4a1d-841c-ff80eaaccfaa]
 description = "clocks with negative hours and minutes that wrap"
-include = true
 
 [96969ca8-875a-48a1-86ae-257a528c44f5]
 description = "full clock and zeroed clock"
-include = true

--- a/exercises/practice/collatz-conjecture/.meta/tests.toml
+++ b/exercises/practice/collatz-conjecture/.meta/tests.toml
@@ -4,24 +4,18 @@
 
 [540a3d51-e7a6-47a5-92a3-4ad1838f0bfd]
 description = "zero steps for one"
-include = true
 
 [3d76a0a6-ea84-444a-821a-f7857c2c1859]
 description = "divide if even"
-include = true
 
 [754dea81-123c-429e-b8bc-db20b05a87b9]
 description = "even and odd steps"
-include = true
 
 [ecfd0210-6f85-44f6-8280-f65534892ff6]
 description = "large number of even and odd steps"
-include = true
 
 [7d4750e6-def9-4b86-aec7-9f7eb44f95a3]
 description = "zero is an error"
-include = true
 
 [c6c795bf-a288-45e9-86a1-841359ad426d]
 description = "negative value is an error"
-include = true

--- a/exercises/practice/complex-numbers/.meta/tests.toml
+++ b/exercises/practice/complex-numbers/.meta/tests.toml
@@ -4,124 +4,93 @@
 
 [9f98e133-eb7f-45b0-9676-cce001cd6f7a]
 description = "Real part of a purely real number"
-include = true
 
 [07988e20-f287-4bb7-90cf-b32c4bffe0f3]
 description = "Real part of a purely imaginary number"
-include = true
 
 [4a370e86-939e-43de-a895-a00ca32da60a]
 description = "Real part of a number with real and imaginary part"
-include = true
 
 [9b3fddef-4c12-4a99-b8f8-e3a42c7ccef6]
 description = "Imaginary part of a purely real number"
-include = true
 
 [a8dafedd-535a-4ed3-8a39-fda103a2b01e]
 description = "Imaginary part of a purely imaginary number"
-include = true
 
 [0f998f19-69ee-4c64-80ef-01b086feab80]
 description = "Imaginary part of a number with real and imaginary part"
-include = true
 
 [a39b7fd6-6527-492f-8c34-609d2c913879]
 description = "Imaginary unit"
-include = true
 
 [9a2c8de9-f068-4f6f-b41c-82232cc6c33e]
 description = "Add purely real numbers"
-include = true
 
 [657c55e1-b14b-4ba7-bd5c-19db22b7d659]
 description = "Add purely imaginary numbers"
-include = true
 
 [4e1395f5-572b-4ce8-bfa9-9a63056888da]
 description = "Add numbers with real and imaginary part"
-include = true
 
 [1155dc45-e4f7-44b8-af34-a91aa431475d]
 description = "Subtract purely real numbers"
-include = true
 
 [f95e9da8-acd5-4da4-ac7c-c861b02f774b]
 description = "Subtract purely imaginary numbers"
-include = true
 
 [f876feb1-f9d1-4d34-b067-b599a8746400]
 description = "Subtract numbers with real and imaginary part"
-include = true
 
 [8a0366c0-9e16-431f-9fd7-40ac46ff4ec4]
 description = "Multiply purely real numbers"
-include = true
 
 [e560ed2b-0b80-4b4f-90f2-63cefc911aaf]
 description = "Multiply purely imaginary numbers"
-include = true
 
 [4d1d10f0-f8d4-48a0-b1d0-f284ada567e6]
 description = "Multiply numbers with real and imaginary part"
-include = true
 
 [b0571ddb-9045-412b-9c15-cd1d816d36c1]
 description = "Divide purely real numbers"
-include = true
 
 [5bb4c7e4-9934-4237-93cc-5780764fdbdd]
 description = "Divide purely imaginary numbers"
-include = true
 
 [c4e7fef5-64ac-4537-91c2-c6529707701f]
 description = "Divide numbers with real and imaginary part"
-include = true
 
 [c56a7332-aad2-4437-83a0-b3580ecee843]
 description = "Absolute value of a positive purely real number"
-include = true
 
 [cf88d7d3-ee74-4f4e-8a88-a1b0090ecb0c]
 description = "Absolute value of a negative purely real number"
-include = true
 
 [bbe26568-86c1-4bb4-ba7a-da5697e2b994]
 description = "Absolute value of a purely imaginary number with positive imaginary part"
-include = true
 
 [3b48233d-468e-4276-9f59-70f4ca1f26f3]
 description = "Absolute value of a purely imaginary number with negative imaginary part"
-include = true
 
 [fe400a9f-aa22-4b49-af92-51e0f5a2a6d3]
 description = "Absolute value of a number with real and imaginary part"
-include = true
 
 [fb2d0792-e55a-4484-9443-df1eddfc84a2]
 description = "Conjugate a purely real number"
-include = true
 
 [e37fe7ac-a968-4694-a460-66cb605f8691]
 description = "Conjugate a purely imaginary number"
-include = true
 
 [f7704498-d0be-4192-aaf5-a1f3a7f43e68]
 description = "Conjugate a number with real and imaginary part"
-include = true
 
 [6d96d4c6-2edb-445b-94a2-7de6d4caaf60]
 description = "Euler's identity/formula"
-include = true
 
 [2d2c05a0-4038-4427-a24d-72f6624aa45f]
 description = "Exponential of 0"
-include = true
 
 [ed87f1bd-b187-45d6-8ece-7e331232c809]
 description = "Exponential of a purely real number"
-include = true
 
 [08eedacc-5a95-44fc-8789-1547b27a8702]
 description = "Exponential of a number with real and imaginary part"
-include = true

--- a/exercises/practice/connect/.meta/tests.toml
+++ b/exercises/practice/connect/.meta/tests.toml
@@ -4,40 +4,30 @@
 
 [6eff0df4-3e92-478d-9b54-d3e8b354db56]
 description = "an empty board has no winner"
-include = true
 
 [298b94c0-b46d-45d8-b34b-0fa2ea71f0a4]
 description = "X can win on a 1x1 board"
-include = true
 
 [763bbae0-cb8f-4f28-bc21-5be16a5722dc]
 description = "O can win on a 1x1 board"
-include = true
 
 [819fde60-9ae2-485e-a024-cbb8ea68751b]
 description = "only edges does not make a winner"
-include = true
 
 [2c56a0d5-9528-41e5-b92b-499dfe08506c]
 description = "illegal diagonal does not make a winner"
-include = true
 
 [41cce3ef-43ca-4963-970a-c05d39aa1cc1]
 description = "nobody wins crossing adjacent angles"
-include = true
 
 [cd61c143-92f6-4a8d-84d9-cb2b359e226b]
 description = "X wins crossing from left to right"
-include = true
 
 [73d1eda6-16ab-4460-9904-b5f5dd401d0b]
 description = "O wins crossing from top to bottom"
-include = true
 
 [c3a2a550-944a-4637-8b3f-1e1bf1340a3d]
 description = "X wins using a convoluted path"
-include = true
 
 [17e76fa8-f731-4db7-92ad-ed2a285d31f3]
 description = "X wins using a spiral path"
-include = true

--- a/exercises/practice/crypto-square/.meta/tests.toml
+++ b/exercises/practice/crypto-square/.meta/tests.toml
@@ -4,28 +4,21 @@
 
 [407c3837-9aa7-4111-ab63-ec54b58e8e9f]
 description = "empty plaintext results in an empty ciphertext"
-include = true
 
 [64131d65-6fd9-4f58-bdd8-4a2370fb481d]
 description = "Lowercase"
-include = true
 
 [63a4b0ed-1e3c-41ea-a999-f6f26ba447d6]
 description = "Remove spaces"
-include = true
 
 [1b5348a1-7893-44c1-8197-42d48d18756c]
 description = "Remove punctuation"
-include = true
 
 [8574a1d3-4a08-4cec-a7c7-de93a164f41a]
 description = "9 character plaintext results in 3 chunks of 3 characters"
-include = true
 
 [a65d3fa1-9e09-43f9-bcec-7a672aec3eae]
 description = "8 character plaintext results in 3 chunks, the last one with a trailing space"
-include = true
 
 [fbcb0c6d-4c39-4a31-83f6-c473baa6af80]
 description = "54 character plaintext results in 7 chunks, the last two with trailing spaces"
-include = true

--- a/exercises/practice/custom-set/.meta/tests.toml
+++ b/exercises/practice/custom-set/.meta/tests.toml
@@ -4,152 +4,114 @@
 
 [20c5f855-f83a-44a7-abdd-fe75c6cf022b]
 description = "sets with no elements are empty"
-include = true
 
 [d506485d-5706-40db-b7d8-5ceb5acf88d2]
 description = "sets with elements are not empty"
-include = true
 
 [759b9740-3417-44c3-8ca3-262b3c281043]
 description = "nothing is contained in an empty set"
-include = true
 
 [f83cd2d1-2a85-41bc-b6be-80adbff4be49]
 description = "when the element is in the set"
-include = true
 
 [93423fc0-44d0-4bc0-a2ac-376de8d7af34]
 description = "when the element is not in the set"
-include = true
 
 [c392923a-637b-4495-b28e-34742cd6157a]
 description = "empty set is a subset of another empty set"
-include = true
 
 [5635b113-be8c-4c6f-b9a9-23c485193917]
 description = "empty set is a subset of non-empty set"
-include = true
 
 [832eda58-6d6e-44e2-92c2-be8cf0173cee]
 description = "non-empty set is not a subset of empty set"
-include = true
 
 [c830c578-8f97-4036-b082-89feda876131]
 description = "set is a subset of set with exact same elements"
-include = true
 
 [476a4a1c-0fd1-430f-aa65-5b70cbc810c5]
 description = "set is a subset of larger set with same elements"
-include = true
 
 [d2498999-3e46-48e4-9660-1e20c3329d3d]
 description = "set is not a subset of set that does not contain its elements"
-include = true
 
 [7d38155e-f472-4a7e-9ad8-5c1f8f95e4cc]
 description = "the empty set is disjoint with itself"
-include = true
 
 [7a2b3938-64b6-4b32-901a-fe16891998a6]
 description = "empty set is disjoint with non-empty set"
-include = true
 
 [589574a0-8b48-48ea-88b0-b652c5fe476f]
 description = "non-empty set is disjoint with empty set"
-include = true
 
 [febeaf4f-f180-4499-91fa-59165955a523]
 description = "sets are not disjoint if they share an element"
-include = true
 
 [0de20d2f-c952-468a-88c8-5e056740f020]
 description = "sets are disjoint if they share no elements"
-include = true
 
 [4bd24adb-45da-4320-9ff6-38c044e9dff8]
 description = "empty sets are equal"
-include = true
 
 [f65c0a0e-6632-4b2d-b82c-b7c6da2ec224]
 description = "empty set is not equal to non-empty set"
-include = true
 
 [81e53307-7683-4b1e-a30c-7e49155fe3ca]
 description = "non-empty set is not equal to empty set"
-include = true
 
 [d57c5d7c-a7f3-48cc-a162-6b488c0fbbd0]
 description = "sets with the same elements are equal"
-include = true
 
 [dd61bafc-6653-42cc-961a-ab071ee0ee85]
 description = "sets with different elements are not equal"
-include = true
 
 [06059caf-9bf4-425e-aaff-88966cb3ea14]
 description = "set is not equal to larger set with same elements"
-include = true
 
 [8a677c3c-a658-4d39-bb88-5b5b1a9659f4]
 description = "add to empty set"
-include = true
 
 [0903dd45-904d-4cf2-bddd-0905e1a8d125]
 description = "add to non-empty set"
-include = true
 
 [b0eb7bb7-5e5d-4733-b582-af771476cb99]
 description = "adding an existing element does not change the set"
-include = true
 
 [893d5333-33b8-4151-a3d4-8f273358208a]
 description = "intersection of two empty sets is an empty set"
-include = true
 
 [d739940e-def2-41ab-a7bb-aaf60f7d782c]
 description = "intersection of an empty set and non-empty set is an empty set"
-include = true
 
 [3607d9d8-c895-4d6f-ac16-a14956e0a4b7]
 description = "intersection of a non-empty set and an empty set is an empty set"
-include = true
 
 [b5120abf-5b5e-41ab-aede-4de2ad85c34e]
 description = "intersection of two sets with no shared elements is an empty set"
-include = true
 
 [af21ca1b-fac9-499c-81c0-92a591653d49]
 description = "intersection of two sets with shared elements is a set of the shared elements"
-include = true
 
 [c5e6e2e4-50e9-4bc2-b89f-c518f015b57e]
 description = "difference of two empty sets is an empty set"
-include = true
 
 [2024cc92-5c26-44ed-aafd-e6ca27d6fcd2]
 description = "difference of empty set and non-empty set is an empty set"
-include = true
 
 [e79edee7-08aa-4c19-9382-f6820974b43e]
 description = "difference of a non-empty set and an empty set is the non-empty set"
-include = true
 
 [c5ac673e-d707-4db5-8d69-7082c3a5437e]
 description = "difference of two non-empty sets is a set of elements that are only in the first set"
-include = true
 
 [c45aed16-5494-455a-9033-5d4c93589dc6]
 description = "union of empty sets is an empty set"
-include = true
 
 [9d258545-33c2-4fcb-a340-9f8aa69e7a41]
 description = "union of an empty set and non-empty set is the non-empty set"
-include = true
 
 [3aade50c-80c7-4db8-853d-75bac5818b83]
 description = "union of a non-empty set and empty set is the non-empty set"
-include = true
 
 [a00bb91f-c4b4-4844-8f77-c73e2e9df77c]
 description = "union of non-empty sets contains all unique elements"
-include = true

--- a/exercises/practice/darts/.meta/tests.toml
+++ b/exercises/practice/darts/.meta/tests.toml
@@ -4,52 +4,39 @@
 
 [9033f731-0a3a-4d9c-b1c0-34a1c8362afb]
 description = "Missed target"
-include = true
 
 [4c9f6ff4-c489-45fd-be8a-1fcb08b4d0ba]
 description = "On the outer circle"
-include = true
 
 [14378687-ee58-4c9b-a323-b089d5274be8]
 description = "On the middle circle"
-include = true
 
 [849e2e63-85bd-4fed-bc3b-781ae962e2c9]
 description = "On the inner circle"
-include = true
 
 [1c5ffd9f-ea66-462f-9f06-a1303de5a226]
 description = "Exactly on centre"
-include = true
 
 [b65abce3-a679-4550-8115-4b74bda06088]
 description = "Near the centre"
-include = true
 
 [66c29c1d-44f5-40cf-9927-e09a1305b399]
 description = "Just within the inner circle"
-include = true
 
 [d1012f63-c97c-4394-b944-7beb3d0b141a]
 description = "Just outside the inner circle"
-include = true
 
 [ab2b5666-b0b4-49c3-9b27-205e790ed945]
 description = "Just within the middle circle"
-include = true
 
 [70f1424e-d690-4860-8caf-9740a52c0161]
 description = "Just outside the middle circle"
-include = true
 
 [a7dbf8db-419c-4712-8a7f-67602b69b293]
 description = "Just within the outer circle"
-include = true
 
 [e0f39315-9f9a-4546-96e4-a9475b885aa7]
 description = "Just outside the outer circle"
-include = true
 
 [045d7d18-d863-4229-818e-b50828c75d19]
 description = "Asymmetric position between the inner and middle circles"
-include = true

--- a/exercises/practice/diamond/.meta/tests.toml
+++ b/exercises/practice/diamond/.meta/tests.toml
@@ -4,20 +4,15 @@
 
 [202fb4cc-6a38-4883-9193-a29d5cb92076]
 description = "Degenerate case with a single 'A' row"
-include = true
 
 [bd6a6d78-9302-42e9-8f60-ac1461e9abae]
 description = "Degenerate case with no row containing 3 distinct groups of spaces"
-include = true
 
 [af8efb49-14ed-447f-8944-4cc59ce3fd76]
 description = "Smallest non-degenerate case with odd diamond side length"
-include = true
 
 [e0c19a95-9888-4d05-86a0-fa81b9e70d1d]
 description = "Smallest non-degenerate case with even diamond side length"
-include = true
 
 [82ea9aa9-4c0e-442a-b07e-40204e925944]
 description = "Largest possible diamond"
-include = true

--- a/exercises/practice/difference-of-squares/.meta/tests.toml
+++ b/exercises/practice/difference-of-squares/.meta/tests.toml
@@ -4,36 +4,27 @@
 
 [e46c542b-31fc-4506-bcae-6b62b3268537]
 description = "square of sum 1"
-include = true
 
 [9b3f96cb-638d-41ee-99b7-b4f9c0622948]
 description = "square of sum 5"
-include = true
 
 [54ba043f-3c35-4d43-86ff-3a41625d5e86]
 description = "square of sum 100"
-include = true
 
 [01d84507-b03e-4238-9395-dd61d03074b5]
 description = "sum of squares 1"
-include = true
 
 [c93900cd-8cc2-4ca4-917b-dd3027023499]
 description = "sum of squares 5"
-include = true
 
 [94807386-73e4-4d9e-8dec-69eb135b19e4]
 description = "sum of squares 100"
-include = true
 
 [44f72ae6-31a7-437f-858d-2c0837adabb6]
 description = "difference of squares 1"
-include = true
 
 [005cb2bf-a0c8-46f3-ae25-924029f8b00b]
 description = "difference of squares 5"
-include = true
 
 [b1bf19de-9a16-41c0-a62b-1f02ecc0b036]
 description = "difference of squares 100"
-include = true

--- a/exercises/practice/dominoes/.meta/tests.toml
+++ b/exercises/practice/dominoes/.meta/tests.toml
@@ -4,48 +4,36 @@
 
 [31a673f2-5e54-49fe-bd79-1c1dae476c9c]
 description = "empty input = empty output"
-include = true
 
 [4f99b933-367b-404b-8c6d-36d5923ee476]
 description = "singleton input = singleton output"
-include = true
 
 [91122d10-5ec7-47cb-b759-033756375869]
 description = "singleton that can't be chained"
-include = true
 
 [be8bc26b-fd3d-440b-8e9f-d698a0623be3]
 description = "three elements"
-include = true
 
 [99e615c6-c059-401c-9e87-ad7af11fea5c]
 description = "can reverse dominoes"
-include = true
 
 [51f0c291-5d43-40c5-b316-0429069528c9]
 description = "can't be chained"
-include = true
 
 [9a75e078-a025-4c23-8c3a-238553657f39]
 description = "disconnected - simple"
-include = true
 
 [0da0c7fe-d492-445d-b9ef-1f111f07a301]
 description = "disconnected - double loop"
-include = true
 
 [b6087ff0-f555-4ea0-a71c-f9d707c5994a]
 description = "disconnected - single isolated"
-include = true
 
 [2174fbdc-8b48-4bac-9914-8090d06ef978]
 description = "need backtrack"
-include = true
 
 [167bb480-dfd1-4318-a20d-4f90adb4a09f]
 description = "separate loops"
-include = true
 
 [cd061538-6046-45a7-ace9-6708fe8f6504]
 description = "nine elements"
-include = true

--- a/exercises/practice/etl/.meta/tests.toml
+++ b/exercises/practice/etl/.meta/tests.toml
@@ -4,16 +4,12 @@
 
 [78a7a9f9-4490-4a47-8ee9-5a38bb47d28f]
 description = "single letter"
-include = true
 
 [60dbd000-451d-44c7-bdbb-97c73ac1f497]
 description = "single score with multiple letters"
-include = true
 
 [f5c5de0c-301f-4fdd-a0e5-df97d4214f54]
 description = "multiple scores with multiple letters"
-include = true
 
 [5db8ea89-ecb4-4dcd-902f-2b418cc87b9d]
 description = "multiple scores with differing numbers of letters"
-include = true

--- a/exercises/practice/forth/.meta/tests.toml
+++ b/exercises/practice/forth/.meta/tests.toml
@@ -4,184 +4,138 @@
 
 [9962203f-f00a-4a85-b404-8a8ecbcec09d]
 description = "numbers just get pushed onto the stack"
-include = true
 
 [9e69588e-a3d8-41a3-a371-ea02206c1e6e]
 description = "can add two numbers"
-include = true
 
 [52336dd3-30da-4e5c-8523-bdf9a3427657]
 description = "errors if there is nothing on the stack"
-include = true
 
 [06efb9a4-817a-435e-b509-06166993c1b8]
 description = "errors if there is only one value on the stack"
-include = true
 
 [09687c99-7bbc-44af-8526-e402f997ccbf]
 description = "can subtract two numbers"
-include = true
 
 [5d63eee2-1f7d-4538-b475-e27682ab8032]
 description = "errors if there is nothing on the stack"
-include = true
 
 [b3cee1b2-9159-418a-b00d-a1bb3765c23b]
 description = "errors if there is only one value on the stack"
-include = true
 
 [5df0ceb5-922e-401f-974d-8287427dbf21]
 description = "can multiply two numbers"
-include = true
 
 [9e004339-15ac-4063-8ec1-5720f4e75046]
 description = "errors if there is nothing on the stack"
-include = true
 
 [8ba4b432-9f94-41e0-8fae-3b3712bd51b3]
 description = "errors if there is only one value on the stack"
-include = true
 
 [e74c2204-b057-4cff-9aa9-31c7c97a93f5]
 description = "can divide two numbers"
-include = true
 
 [54f6711c-4b14-4bb0-98ad-d974a22c4620]
 description = "performs integer division"
-include = true
 
 [a5df3219-29b4-4d2f-b427-81f82f42a3f1]
 description = "errors if dividing by zero"
-include = true
 
 [1d5bb6b3-6749-4e02-8a79-b5d4d334cb8a]
 description = "errors if there is nothing on the stack"
-include = true
 
 [d5547f43-c2ff-4d5c-9cb0-2a4f6684c20d]
 description = "errors if there is only one value on the stack"
-include = true
 
 [ee28d729-6692-4a30-b9be-0d830c52a68c]
 description = "addition and subtraction"
-include = true
 
 [40b197da-fa4b-4aca-a50b-f000d19422c1]
 description = "multiplication and division"
-include = true
 
 [c5758235-6eef-4bf6-ab62-c878e50b9957]
 description = "copies a value on the stack"
-include = true
 
 [f6889006-5a40-41e7-beb3-43b09e5a22f4]
 description = "copies the top value on the stack"
-include = true
 
 [40b7569c-8401-4bd4-a30d-9adf70d11bc4]
 description = "errors if there is nothing on the stack"
-include = true
 
 [1971da68-1df2-4569-927a-72bf5bb7263c]
 description = "removes the top value on the stack if it is the only one"
-include = true
 
 [8929d9f2-4a78-4e0f-90ad-be1a0f313fd9]
 description = "removes the top value on the stack if it is not the only one"
-include = true
 
 [6dd31873-6dd7-4cb8-9e90-7daa33ba045c]
 description = "errors if there is nothing on the stack"
-include = true
 
 [3ee68e62-f98a-4cce-9e6c-8aae6c65a4e3]
 description = "swaps the top two values on the stack if they are the only ones"
-include = true
 
 [8ce869d5-a503-44e4-ab55-1da36816ff1c]
 description = "swaps the top two values on the stack if they are not the only ones"
-include = true
 
 [74ba5b2a-b028-4759-9176-c5c0e7b2b154]
 description = "errors if there is nothing on the stack"
-include = true
 
 [dd52e154-5d0d-4a5c-9e5d-73eb36052bc8]
 description = "errors if there is only one value on the stack"
-include = true
 
 [a2654074-ba68-4f93-b014-6b12693a8b50]
 description = "copies the second element if there are only two"
-include = true
 
 [c5b51097-741a-4da7-8736-5c93fa856339]
 description = "copies the second element if there are more than two"
-include = true
 
 [6e1703a6-5963-4a03-abba-02e77e3181fd]
 description = "errors if there is nothing on the stack"
-include = true
 
 [ee574dc4-ef71-46f6-8c6a-b4af3a10c45f]
 description = "errors if there is only one value on the stack"
-include = true
 
 [ed45cbbf-4dbf-4901-825b-54b20dbee53b]
 description = "can consist of built-in words"
-include = true
 
 [2726ea44-73e4-436b-bc2b-5ff0c6aa014b]
 description = "execute in the right order"
-include = true
 
 [9e53c2d0-b8ef-4ad8-b2c9-a559b421eb33]
 description = "can override other user-defined words"
-include = true
 
 [669db3f3-5bd6-4be0-83d1-618cd6e4984b]
 description = "can override built-in words"
-include = true
 
 [588de2f0-c56e-4c68-be0b-0bb1e603c500]
 description = "can override built-in operators"
-include = true
 
 [ac12aaaf-26c6-4a10-8b3c-1c958fa2914c]
 description = "can use different words with the same name"
-include = true
 
 [53f82ef0-2750-4ccb-ac04-5d8c1aefabb1]
 description = "can define word that uses word with the same name"
-include = true
 
 [35958cee-a976-4a0f-9378-f678518fa322]
 description = "cannot redefine numbers"
-include = true
 
 [5180f261-89dd-491e-b230-62737e09806f]
 description = "errors if executing a non-existent word"
-include = true
 
 [7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6]
 description = "DUP is case-insensitive"
-include = true
 
 [339ed30b-f5b4-47ff-ab1c-67591a9cd336]
 description = "DROP is case-insensitive"
-include = true
 
 [ee1af31e-1355-4b1b-bb95-f9d0b2961b87]
 description = "SWAP is case-insensitive"
-include = true
 
 [acdc3a49-14c8-4cc2-945d-11edee6408fa]
 description = "OVER is case-insensitive"
-include = true
 
 [5934454f-a24f-4efc-9fdd-5794e5f0c23c]
 description = "user-defined words are case-insensitive"
-include = true
 
 [037d4299-195f-4be7-a46d-f07ca6280a06]
 description = "definitions are case-insensitive"
-include = true

--- a/exercises/practice/gigasecond/.meta/tests.toml
+++ b/exercises/practice/gigasecond/.meta/tests.toml
@@ -4,20 +4,15 @@
 
 [92fbe71c-ea52-4fac-bd77-be38023cacf7]
 description = "date only specification of time"
-include = true
 
 [6d86dd16-6f7a-47be-9e58-bb9fb2ae1433]
 description = "second test for date only specification of time"
-include = true
 
 [77eb8502-2bca-4d92-89d9-7b39ace28dd5]
 description = "third test for date only specification of time"
-include = true
 
 [c9d89a7d-06f8-4e28-a305-64f1b2abc693]
 description = "full time specified"
-include = true
 
 [09d4e30e-728a-4b52-9005-be44a58d9eba]
 description = "full time with day roll-over"
-include = true

--- a/exercises/practice/grade-school/.meta/tests.toml
+++ b/exercises/practice/grade-school/.meta/tests.toml
@@ -4,7 +4,6 @@
 
 [6d0a30e4-1b4e-472e-8e20-c41702125667]
 description = "Adding a student adds them to the sorted roster"
-include = true
 
 [c125dab7-2a53-492f-a99a-56ad511940d8]
 description = "A student can't be in two different grades"
@@ -16,24 +15,18 @@ comments = [
 
 [233be705-dd58-4968-889d-fb3c7954c9cc]
 description = "Adding more student adds them to the sorted roster"
-include = true
 
 [75a51579-d1d7-407c-a2f8-2166e984e8ab]
 description = "Adding students to different grades adds them to the same sorted roster"
-include = true
 
 [a3f0fb58-f240-4723-8ddc-e644666b85cc]
 description = "Roster returns an empty list if there are no students enrolled"
-include = true
 
 [180a8ff9-5b94-43fc-9db1-d46b4a8c93b6]
 description = "Student names with grades are displayed in the same sorted roster"
-include = true
 
 [1bfbcef1-e4a3-49e8-8d22-f6f9f386187e]
 description = "Grade returns the students in that grade in alphabetical order"
-include = true
 
 [5e67aa3c-a3c6-4407-a183-d8fe59cd1630]
 description = "Grade returns an empty list if there are no students in that grade"
-include = true

--- a/exercises/practice/grains/.meta/tests.toml
+++ b/exercises/practice/grains/.meta/tests.toml
@@ -4,44 +4,33 @@
 
 [9fbde8de-36b2-49de-baf2-cd42d6f28405]
 description = "1"
-include = true
 
 [ee1f30c2-01d8-4298-b25d-c677331b5e6d]
 description = "2"
-include = true
 
 [10f45584-2fc3-4875-8ec6-666065d1163b]
 description = "3"
-include = true
 
 [a7cbe01b-36f4-4601-b053-c5f6ae055170]
 description = "4"
-include = true
 
 [c50acc89-8535-44e4-918f-b848ad2817d4]
 description = "16"
-include = true
 
 [acd81b46-c2ad-4951-b848-80d15ed5a04f]
 description = "32"
-include = true
 
 [c73b470a-5efb-4d53-9ac6-c5f6487f227b]
 description = "64"
-include = true
 
 [1d47d832-3e85-4974-9466-5bd35af484e3]
 description = "square 0 raises an exception"
-include = true
 
 [61974483-eeb2-465e-be54-ca5dde366453]
 description = "negative square raises an exception"
-include = true
 
 [a95e4374-f32c-45a7-a10d-ffec475c012f]
 description = "square greater than 64 raises an exception"
-include = true
 
 [6eb07385-3659-4b45-a6be-9dc474222750]
 description = "returns the total number of grains on the board"
-include = true

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -4,31 +4,24 @@
 
 [f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]
 description = "empty strands"
-include = true
 
 [54681314-eee2-439a-9db0-b0636c656156]
 description = "single letter identical strands"
-include = true
 
 [294479a3-a4c8-478f-8d63-6209815a827b]
 description = "single letter different strands"
-include = true
 
 [9aed5f34-5693-4344-9b31-40c692fb5592]
 description = "long identical strands"
-include = true
 
 [cd2273a5-c576-46c8-a52b-dee251c3e6e5]
 description = "long different strands"
-include = true
 
 [919f8ef0-b767-4d1b-8516-6379d07fcb28]
 description = "disallow first strand longer"
-include = true
 
 [8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
 description = "disallow second strand longer"
-include = true
 
 [5dce058b-28d4-4ca7-aa64-adfe4e17784c]
 description = "disallow left empty strand"
@@ -46,8 +39,6 @@ include = false
 
 [db92e77e-7c72-499d-8fe6-9354d2bfd504]
 description = "disallow left empty strand"
-include = true
 
 [920cd6e3-18f4-4143-b6b8-74270bb8f8a3]
 description = "disallow right empty strand"
-include = true

--- a/exercises/practice/hello-world/.meta/tests.toml
+++ b/exercises/practice/hello-world/.meta/tests.toml
@@ -4,4 +4,3 @@
 
 [af9ffe10-dc13-42d8-a742-e7bdafac449d]
 description = "Say Hi!"
-include = true

--- a/exercises/practice/isbn-verifier/.meta/tests.toml
+++ b/exercises/practice/isbn-verifier/.meta/tests.toml
@@ -4,68 +4,51 @@
 
 [0caa3eac-d2e3-4c29-8df8-b188bc8c9292]
 description = "valid isbn number"
-include = true
 
 [19f76b53-7c24-45f8-87b8-4604d0ccd248]
 description = "invalid isbn check digit"
-include = true
 
 [4164bfee-fb0a-4a1c-9f70-64c6a1903dcd]
 description = "valid isbn number with a check digit of 10"
-include = true
 
 [3ed50db1-8982-4423-a993-93174a20825c]
 description = "check digit is a character other than X"
-include = true
 
 [c19ba0c4-014f-4dc3-a63f-ff9aefc9b5ec]
 description = "invalid character in isbn"
-include = true
 
 [28025280-2c39-4092-9719-f3234b89c627]
 description = "X is only valid as a check digit"
-include = true
 
 [f6294e61-7e79-46b3-977b-f48789a4945b]
 description = "valid isbn without separating dashes"
-include = true
 
 [185ab99b-3a1b-45f3-aeec-b80d80b07f0b]
 description = "isbn without separating dashes and X as check digit"
-include = true
 
 [7725a837-ec8e-4528-a92a-d981dd8cf3e2]
 description = "isbn without check digit and dashes"
-include = true
 
 [47e4dfba-9c20-46ed-9958-4d3190630bdf]
 description = "too long isbn and no dashes"
-include = true
 
 [737f4e91-cbba-4175-95bf-ae630b41fb60]
 description = "too short isbn"
-include = true
 
 [5458a128-a9b6-4ff8-8afb-674e74567cef]
 description = "isbn without check digit"
-include = true
 
 [70b6ad83-d0a2-4ca7-a4d5-a9ab731800f7]
 description = "check digit of X should not be used for 0"
-include = true
 
 [94610459-55ab-4c35-9b93-ff6ea1a8e562]
 description = "empty isbn"
-include = true
 
 [7bff28d4-d770-48cc-80d6-b20b3a0fb46c]
 description = "input is 9 characters"
-include = true
 
 [ed6e8d1b-382c-4081-8326-8b772c581fec]
 description = "invalid characters are not ignored"
-include = true
 
 [fb5e48d8-7c03-4bfb-a088-b101df16fdc3]
 description = "input is too long but contains a valid isbn"
-include = true

--- a/exercises/practice/isogram/.meta/tests.toml
+++ b/exercises/practice/isogram/.meta/tests.toml
@@ -4,52 +4,39 @@
 
 [a0e97d2d-669e-47c7-8134-518a1e2c4555]
 description = "empty string"
-include = true
 
 [9a001b50-f194-4143-bc29-2af5ec1ef652]
 description = "isogram with only lower case characters"
-include = true
 
 [8ddb0ca3-276e-4f8b-89da-d95d5bae78a4]
 description = "word with one duplicated character"
-include = true
 
 [6450b333-cbc2-4b24-a723-0b459b34fe18]
 description = "word with one duplicated character from the end of the alphabet"
-include = true
 
 [a15ff557-dd04-4764-99e7-02cc1a385863]
 description = "longest reported english isogram"
-include = true
 
 [f1a7f6c7-a42f-4915-91d7-35b2ea11c92e]
 description = "word with duplicated character in mixed case"
-include = true
 
 [14a4f3c1-3b47-4695-b645-53d328298942]
 description = "word with duplicated character in mixed case, lowercase first"
-include = true
 
 [423b850c-7090-4a8a-b057-97f1cadd7c42]
 description = "hypothetical isogrammic word with hyphen"
-include = true
 
 [93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2]
 description = "hypothetical word with duplicated character following hyphen"
-include = true
 
 [36b30e5c-173f-49c6-a515-93a3e825553f]
 description = "isogram with duplicated hyphen"
-include = true
 
 [cdabafa0-c9f4-4c1f-b142-689c6ee17d93]
 description = "made-up name that is an isogram"
-include = true
 
 [5fc61048-d74e-48fd-bc34-abfc21552d4d]
 description = "duplicated character in the middle"
-include = true
 
 [310ac53d-8932-47bc-bbb4-b2b94f25a83e]
 description = "same first and last characters"
-include = true

--- a/exercises/practice/largest-series-product/.meta/tests.toml
+++ b/exercises/practice/largest-series-product/.meta/tests.toml
@@ -4,60 +4,45 @@
 
 [7c82f8b7-e347-48ee-8a22-f672323324d4]
 description = "finds the largest product if span equals length"
-include = true
 
 [88523f65-21ba-4458-a76a-b4aaf6e4cb5e]
 description = "can find the largest product of 2 with numbers in order"
-include = true
 
 [f1376b48-1157-419d-92c2-1d7e36a70b8a]
 description = "can find the largest product of 2"
-include = true
 
 [46356a67-7e02-489e-8fea-321c2fa7b4a4]
 description = "can find the largest product of 3 with numbers in order"
-include = true
 
 [a2dcb54b-2b8f-4993-92dd-5ce56dece64a]
 description = "can find the largest product of 3"
-include = true
 
 [673210a3-33cd-4708-940b-c482d7a88f9d]
 description = "can find the largest product of 5 with numbers in order"
-include = true
 
 [02acd5a6-3bbf-46df-8282-8b313a80a7c9]
 description = "can get the largest product of a big number"
-include = true
 
 [76dcc407-21e9-424c-a98e-609f269622b5]
 description = "reports zero if the only digits are zero"
-include = true
 
 [6ef0df9f-52d4-4a5d-b210-f6fae5f20e19]
 description = "reports zero if all spans include zero"
-include = true
 
 [5d81aaf7-4f67-4125-bf33-11493cc7eab7]
 description = "rejects span longer than string length"
-include = true
 
 [06bc8b90-0c51-4c54-ac22-3ec3893a079e]
 description = "reports 1 for empty string and empty product (0 span)"
-include = true
 
 [3ec0d92e-f2e2-4090-a380-70afee02f4c0]
 description = "reports 1 for nonempty string and empty product (0 span)"
-include = true
 
 [6d96c691-4374-4404-80ee-2ea8f3613dd4]
 description = "rejects empty string and nonzero span"
-include = true
 
 [7a38f2d6-3c35-45f6-8d6f-12e6e32d4d74]
 description = "rejects invalid character in digits"
-include = true
 
 [5fe3c0e5-a945-49f2-b584-f0814b4dd1ef]
 description = "rejects negative span"
-include = true

--- a/exercises/practice/leap/.meta/tests.toml
+++ b/exercises/practice/leap/.meta/tests.toml
@@ -4,36 +4,27 @@
 
 [6466b30d-519c-438e-935d-388224ab5223]
 description = "year not divisible by 4 in common year"
-include = true
 
 [ac227e82-ee82-4a09-9eb6-4f84331ffdb0]
 description = "year divisible by 2, not divisible by 4 in common year"
-include = true
 
 [4fe9b84c-8e65-489e-970b-856d60b8b78e]
 description = "year divisible by 4, not divisible by 100 in leap year"
-include = true
 
 [7fc6aed7-e63c-48f5-ae05-5fe182f60a5d]
 description = "year divisible by 4 and 5 is still a leap year"
-include = true
 
 [78a7848f-9667-4192-ae53-87b30c9a02dd]
 description = "year divisible by 100, not divisible by 400 in common year"
-include = true
 
 [9d70f938-537c-40a6-ba19-f50739ce8bac]
 description = "year divisible by 100 but not by 3 is still not a leap year"
-include = true
 
 [42ee56ad-d3e6-48f1-8e3f-c84078d916fc]
 description = "year divisible by 400 in leap year"
-include = true
 
 [57902c77-6fe9-40de-8302-587b5c27121e]
 description = "year divisible by 400 but not by 125 is still a leap year"
-include = true
 
 [c30331f6-f9f6-4881-ad38-8ca8c12520c1]
 description = "year divisible by 200, not divisible by 400 in common year"
-include = true

--- a/exercises/practice/luhn/.meta/tests.toml
+++ b/exercises/practice/luhn/.meta/tests.toml
@@ -4,72 +4,54 @@
 
 [792a7082-feb7-48c7-b88b-bbfec160865e]
 description = "single digit strings can not be valid"
-include = true
 
 [698a7924-64d4-4d89-8daa-32e1aadc271e]
 description = "a single zero is invalid"
-include = true
 
 [73c2f62b-9b10-4c9f-9a04-83cee7367965]
 description = "a simple valid SIN that remains valid if reversed"
-include = true
 
 [9369092e-b095-439f-948d-498bd076be11]
 description = "a simple valid SIN that becomes invalid if reversed"
-include = true
 
 [8f9f2350-1faf-4008-ba84-85cbb93ffeca]
 description = "a valid Canadian SIN"
-include = true
 
 [1cdcf269-6560-44fc-91f6-5819a7548737]
 description = "invalid Canadian SIN"
-include = true
 
 [656c48c1-34e8-4e60-9a5a-aad8a367810a]
 description = "invalid credit card"
-include = true
 
 [20e67fad-2121-43ed-99a8-14b5b856adb9]
 description = "invalid long number with an even remainder"
-include = true
 
 [ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa]
 description = "valid number with an even number of digits"
-include = true
 
 [ef081c06-a41f-4761-8492-385e13c8202d]
 description = "valid number with an odd number of spaces"
-include = true
 
 [bef66f64-6100-4cbb-8f94-4c9713c5e5b2]
 description = "valid strings with a non-digit added at the end become invalid"
-include = true
 
 [2177e225-9ce7-40f6-b55d-fa420e62938e]
 description = "valid strings with punctuation included become invalid"
-include = true
 
 [ebf04f27-9698-45e1-9afe-7e0851d0fe8d]
 description = "valid strings with symbols included become invalid"
-include = true
 
 [08195c5e-ce7f-422c-a5eb-3e45fece68ba]
 description = "single zero with space is invalid"
-include = true
 
 [12e63a3c-f866-4a79-8c14-b359fc386091]
 description = "more than a single zero is valid"
-include = true
 
 [ab56fa80-5de8-4735-8a4a-14dae588663e]
 description = "input digit 9 is correctly converted to output digit 9"
-include = true
 
 [39a06a5a-5bad-4e0f-b215-b042d46209b1]
 description = "using ascii value for non-doubled non-digit isn't allowed"
-include = true
 
 [f94cf191-a62f-4868-bc72-7253114aa157]
 description = "using ascii value for doubled non-digit isn't allowed"
-include = true

--- a/exercises/practice/meetup/.meta/tests.toml
+++ b/exercises/practice/meetup/.meta/tests.toml
@@ -4,380 +4,285 @@
 
 [d7f8eadd-d4fc-46ee-8a20-e97bd3fd01c8]
 description = "monteenth of May 2013"
-include = true
 
 [f78373d1-cd53-4a7f-9d37-e15bf8a456b4]
 description = "monteenth of August 2013"
-include = true
 
 [8c78bea7-a116-425b-9c6b-c9898266d92a]
 description = "monteenth of September 2013"
-include = true
 
 [cfef881b-9dc9-4d0b-8de4-82d0f39fc271]
 description = "tuesteenth of March 2013"
-include = true
 
 [69048961-3b00-41f9-97ee-eb6d83a8e92b]
 description = "tuesteenth of April 2013"
-include = true
 
 [d30bade8-3622-466a-b7be-587414e0caa6]
 description = "tuesteenth of August 2013"
-include = true
 
 [8db4b58b-92f3-4687-867b-82ee1a04f851]
 description = "wednesteenth of January 2013"
-include = true
 
 [6c27a2a2-28f8-487f-ae81-35d08c4664f7]
 description = "wednesteenth of February 2013"
-include = true
 
 [008a8674-1958-45b5-b8e6-c2c9960d973a]
 description = "wednesteenth of June 2013"
-include = true
 
 [e4abd5e3-57cb-4091-8420-d97e955c0dbd]
 description = "thursteenth of May 2013"
-include = true
 
 [85da0b0f-eace-4297-a6dd-63588d5055b4]
 description = "thursteenth of June 2013"
-include = true
 
 [ecf64f9b-8413-489b-bf6e-128045f70bcc]
 description = "thursteenth of September 2013"
-include = true
 
 [ac4e180c-7d0a-4d3d-b05f-f564ebb584ca]
 description = "friteenth of April 2013"
-include = true
 
 [b79101c7-83ad-4f8f-8ec8-591683296315]
 description = "friteenth of August 2013"
-include = true
 
 [6ed38b9f-0072-4901-bd97-7c8b8b0ef1b8]
 description = "friteenth of September 2013"
-include = true
 
 [dfae03ed-9610-47de-a632-655ab01e1e7c]
 description = "saturteenth of February 2013"
-include = true
 
 [ec02e3e1-fc72-4a3c-872f-a53fa8ab358e]
 description = "saturteenth of April 2013"
-include = true
 
 [d983094b-7259-4195-b84e-5d09578c89d9]
 description = "saturteenth of October 2013"
-include = true
 
 [d84a2a2e-f745-443a-9368-30051be60c2e]
 description = "sunteenth of May 2013"
-include = true
 
 [0e64bc53-92a3-4f61-85b2-0b7168c7ce5a]
 description = "sunteenth of June 2013"
-include = true
 
 [de87652c-185e-4854-b3ae-04cf6150eead]
 description = "sunteenth of October 2013"
-include = true
 
 [2cbfd0f5-ba3a-46da-a8cc-0fe4966d3411]
 description = "first Monday of March 2013"
-include = true
 
 [a6168c7c-ed95-4bb3-8f92-c72575fc64b0]
 description = "first Monday of April 2013"
-include = true
 
 [1bfc620f-1c54-4bbd-931f-4a1cd1036c20]
 description = "first Tuesday of May 2013"
-include = true
 
 [12959c10-7362-4ca0-a048-50cf1c06e3e2]
 description = "first Tuesday of June 2013"
-include = true
 
 [1033dc66-8d0b-48a1-90cb-270703d59d1d]
 description = "first Wednesday of July 2013"
-include = true
 
 [b89185b9-2f32-46f4-a602-de20b09058f6]
 description = "first Wednesday of August 2013"
-include = true
 
 [53aedc4d-b2c8-4dfb-abf7-a8dc9cdceed5]
 description = "first Thursday of September 2013"
-include = true
 
 [b420a7e3-a94c-4226-870a-9eb3a92647f0]
 description = "first Thursday of October 2013"
-include = true
 
 [61df3270-28b4-4713-bee2-566fa27302ca]
 description = "first Friday of November 2013"
-include = true
 
 [cad33d4d-595c-412f-85cf-3874c6e07abf]
 description = "first Friday of December 2013"
-include = true
 
 [a2869b52-5bba-44f0-a863-07bd1f67eadb]
 description = "first Saturday of January 2013"
-include = true
 
 [3585315a-d0db-4ea1-822e-0f22e2a645f5]
 description = "first Saturday of February 2013"
-include = true
 
 [c49e9bd9-8ccf-4cf2-947a-0ccd4e4f10b1]
 description = "first Sunday of March 2013"
-include = true
 
 [1513328b-df53-4714-8677-df68c4f9366c]
 description = "first Sunday of April 2013"
-include = true
 
 [49e083af-47ec-4018-b807-62ef411efed7]
 description = "second Monday of March 2013"
-include = true
 
 [6cb79a73-38fe-4475-9101-9eec36cf79e5]
 description = "second Monday of April 2013"
-include = true
 
 [4c39b594-af7e-4445-aa03-bf4f8effd9a1]
 description = "second Tuesday of May 2013"
-include = true
 
 [41b32c34-2e39-40e3-b790-93539aaeb6dd]
 description = "second Tuesday of June 2013"
-include = true
 
 [90a160c5-b5d9-4831-927f-63a78b17843d]
 description = "second Wednesday of July 2013"
-include = true
 
 [23b98ce7-8dd5-41a1-9310-ef27209741cb]
 description = "second Wednesday of August 2013"
-include = true
 
 [447f1960-27ca-4729-bc3f-f36043f43ed0]
 description = "second Thursday of September 2013"
-include = true
 
 [c9aa2687-300c-4e79-86ca-077849a81bde]
 description = "second Thursday of October 2013"
-include = true
 
 [a7e11ef3-6625-4134-acda-3e7195421c09]
 description = "second Friday of November 2013"
-include = true
 
 [8b420e5f-9290-4106-b5ae-022f3e2a3e41]
 description = "second Friday of December 2013"
-include = true
 
 [80631afc-fc11-4546-8b5f-c12aaeb72b4f]
 description = "second Saturday of January 2013"
-include = true
 
 [e34d43ac-f470-44c2-aa5f-e97b78ecaf83]
 description = "second Saturday of February 2013"
-include = true
 
 [a57d59fd-1023-47ad-b0df-a6feb21b44fc]
 description = "second Sunday of March 2013"
-include = true
 
 [a829a8b0-abdd-4ad1-b66c-5560d843c91a]
 description = "second Sunday of April 2013"
-include = true
 
 [501a8a77-6038-4fc0-b74c-33634906c29d]
 description = "third Monday of March 2013"
-include = true
 
 [49e4516e-cf32-4a58-8bbc-494b7e851c92]
 description = "third Monday of April 2013"
-include = true
 
 [4db61095-f7c7-493c-85f1-9996ad3012c7]
 description = "third Tuesday of May 2013"
-include = true
 
 [714fc2e3-58d0-4b91-90fd-61eefd2892c0]
 description = "third Tuesday of June 2013"
-include = true
 
 [b08a051a-2c80-445b-9b0e-524171a166d1]
 description = "third Wednesday of July 2013"
-include = true
 
 [80bb9eff-3905-4c61-8dc9-bb03016d8ff8]
 description = "third Wednesday of August 2013"
-include = true
 
 [fa52a299-f77f-4784-b290-ba9189fbd9c9]
 description = "third Thursday of September 2013"
-include = true
 
 [f74b1bc6-cc5c-4bf1-ba69-c554a969eb38]
 description = "third Thursday of October 2013"
-include = true
 
 [8900f3b0-801a-466b-a866-f42d64667abd]
 description = "third Friday of November 2013"
-include = true
 
 [538ac405-a091-4314-9ccd-920c4e38e85e]
 description = "third Friday of December 2013"
-include = true
 
 [244db35c-2716-4fa0-88ce-afd58e5cf910]
 description = "third Saturday of January 2013"
-include = true
 
 [dd28544f-f8fa-4f06-9bcd-0ad46ce68e9e]
 description = "third Saturday of February 2013"
-include = true
 
 [be71dcc6-00d2-4b53-a369-cbfae55b312f]
 description = "third Sunday of March 2013"
-include = true
 
 [b7d2da84-4290-4ee6-a618-ee124ae78be7]
 description = "third Sunday of April 2013"
-include = true
 
 [4276dc06-a1bd-4fc2-b6c2-625fee90bc88]
 description = "fourth Monday of March 2013"
-include = true
 
 [ddbd7976-2deb-4250-8a38-925ac1a8e9a2]
 description = "fourth Monday of April 2013"
-include = true
 
 [eb714ef4-1656-47cc-913c-844dba4ebddd]
 description = "fourth Tuesday of May 2013"
-include = true
 
 [16648435-7937-4d2d-b118-c3e38fd084bd]
 description = "fourth Tuesday of June 2013"
-include = true
 
 [de062bdc-9484-437a-a8c5-5253c6f6785a]
 description = "fourth Wednesday of July 2013"
-include = true
 
 [c2ce6821-169c-4832-8d37-690ef5d9514a]
 description = "fourth Wednesday of August 2013"
-include = true
 
 [d462c631-2894-4391-a8e3-dbb98b7a7303]
 description = "fourth Thursday of September 2013"
-include = true
 
 [9ff1f7b6-1b72-427d-9ee9-82b5bb08b835]
 description = "fourth Thursday of October 2013"
-include = true
 
 [83bae8ba-1c49-49bc-b632-b7c7e1d7e35f]
 description = "fourth Friday of November 2013"
-include = true
 
 [de752d2a-a95e-48d2-835b-93363dac3710]
 description = "fourth Friday of December 2013"
-include = true
 
 [eedd90ad-d581-45db-8312-4c6dcf9cf560]
 description = "fourth Saturday of January 2013"
-include = true
 
 [669fedcd-912e-48c7-a0a1-228b34af91d0]
 description = "fourth Saturday of February 2013"
-include = true
 
 [648e3849-ea49-44a5-a8a3-9f2a43b3bf1b]
 description = "fourth Sunday of March 2013"
-include = true
 
 [f81321b3-99ab-4db6-9267-69c5da5a7823]
 description = "fourth Sunday of April 2013"
-include = true
 
 [1af5e51f-5488-4548-aee8-11d7d4a730dc]
 description = "last Monday of March 2013"
-include = true
 
 [f29999f2-235e-4ec7-9dab-26f137146526]
 description = "last Monday of April 2013"
-include = true
 
 [31b097a0-508e-48ac-bf8a-f63cdcf6dc41]
 description = "last Tuesday of May 2013"
-include = true
 
 [8c022150-0bb5-4a1f-80f9-88b2e2abcba4]
 description = "last Tuesday of June 2013"
-include = true
 
 [0e762194-672a-4bdf-8a37-1e59fdacef12]
 description = "last Wednesday of July 2013"
-include = true
 
 [5016386a-f24e-4bd7-b439-95358f491b66]
 description = "last Wednesday of August 2013"
-include = true
 
 [12ead1a5-cdf9-4192-9a56-2229e93dd149]
 description = "last Thursday of September 2013"
-include = true
 
 [7db89e11-7fbe-4e57-ae3c-0f327fbd7cc7]
 description = "last Thursday of October 2013"
-include = true
 
 [e47a739e-b979-460d-9c8a-75c35ca2290b]
 description = "last Friday of November 2013"
-include = true
 
 [5bed5aa9-a57a-4e5d-8997-2cc796a5b0ec]
 description = "last Friday of December 2013"
-include = true
 
 [61e54cba-76f3-4772-a2b1-bf443fda2137]
 description = "last Saturday of January 2013"
-include = true
 
 [8b6a737b-2fa9-444c-b1a2-80ce7a2ec72f]
 description = "last Saturday of February 2013"
-include = true
 
 [0b63e682-f429-4d19-9809-4a45bd0242dc]
 description = "last Sunday of March 2013"
-include = true
 
 [5232307e-d3e3-4afc-8ba6-4084ad987c00]
 description = "last Sunday of April 2013"
-include = true
 
 [0bbd48e8-9773-4e81-8e71-b9a51711e3c5]
 description = "last Wednesday of February 2012"
-include = true
 
 [fe0936de-7eee-4a48-88dd-66c07ab1fefc]
 description = "last Wednesday of December 2014"
-include = true
 
 [2ccf2488-aafc-4671-a24e-2b6effe1b0e2]
 description = "last Sunday of February 2015"
-include = true
 
 [00c3ce9f-cf36-4b70-90d8-92b32be6830e]
 description = "first Friday of December 2012"
-include = true

--- a/exercises/practice/minesweeper/.meta/tests.toml
+++ b/exercises/practice/minesweeper/.meta/tests.toml
@@ -4,48 +4,36 @@
 
 [0c5ec4bd-dea7-4138-8651-1203e1cb9f44]
 description = "no rows"
-include = true
 
 [650ac4c0-ad6b-4b41-acde-e4ea5852c3b8]
 description = "no columns"
-include = true
 
 [6fbf8f6d-a03b-42c9-9a58-b489e9235478]
 description = "no mines"
-include = true
 
 [61aff1c4-fb31-4078-acad-cd5f1e635655]
 description = "minefield with only mines"
-include = true
 
 [84167147-c504-4896-85d7-246b01dea7c5]
 description = "mine surrounded by spaces"
-include = true
 
 [cb878f35-43e3-4c9d-93d9-139012cccc4a]
 description = "space surrounded by mines"
-include = true
 
 [7037f483-ddb4-4b35-b005-0d0f4ef4606f]
 description = "horizontal line"
-include = true
 
 [e359820f-bb8b-4eda-8762-47b64dba30a6]
 description = "horizontal line, mines at edges"
-include = true
 
 [c5198b50-804f-47e9-ae02-c3b42f7ce3ab]
 description = "vertical line"
-include = true
 
 [0c79a64d-703d-4660-9e90-5adfa5408939]
 description = "vertical line, mines at edges"
-include = true
 
 [4b098563-b7f3-401c-97c6-79dd1b708f34]
 description = "cross"
-include = true
 
 [04a260f1-b40a-4e89-839e-8dd8525abe0e]
 description = "large minefield"
-include = true

--- a/exercises/practice/nth-prime/.meta/tests.toml
+++ b/exercises/practice/nth-prime/.meta/tests.toml
@@ -4,20 +4,15 @@
 
 [75c65189-8aef-471a-81de-0a90c728160c]
 description = "first prime"
-include = true
 
 [2c38804c-295f-4701-b728-56dea34fd1a0]
 description = "second prime"
-include = true
 
 [56692534-781e-4e8c-b1f9-3e82c1640259]
 description = "sixth prime"
-include = true
 
 [fce1e979-0edb-412d-93aa-2c744e8f50ff]
 description = "big prime"
-include = true
 
 [bd0a9eae-6df7-485b-a144-80e13c7d55b2]
 description = "there is no zeroth prime"
-include = true

--- a/exercises/practice/nucleotide-count/.meta/tests.toml
+++ b/exercises/practice/nucleotide-count/.meta/tests.toml
@@ -4,20 +4,15 @@
 
 [3e5c30a8-87e2-4845-a815-a49671ade970]
 description = "empty strand"
-include = true
 
 [a0ea42a6-06d9-4ac6-828c-7ccaccf98fec]
 description = "can count one nucleotide in single-character input"
-include = true
 
 [eca0d565-ed8c-43e7-9033-6cefbf5115b5]
 description = "strand with repeated nucleotide"
-include = true
 
 [40a45eac-c83f-4740-901a-20b22d15a39f]
 description = "strand with multiple nucleotides"
-include = true
 
 [b4c47851-ee9e-4b0a-be70-a86e343bd851]
 description = "strand with invalid nucleotides"
-include = true

--- a/exercises/practice/palindrome-products/.meta/tests.toml
+++ b/exercises/practice/palindrome-products/.meta/tests.toml
@@ -4,48 +4,36 @@
 
 [5cff78fe-cf02-459d-85c2-ce584679f887]
 description = "finds the smallest palindrome from single digit factors"
-include = true
 
 [0853f82c-5fc4-44ae-be38-fadb2cced92d]
 description = "finds the largest palindrome from single digit factors"
-include = true
 
 [66c3b496-bdec-4103-9129-3fcb5a9063e1]
 description = "find the smallest palindrome from double digit factors"
-include = true
 
 [a10682ae-530a-4e56-b89d-69664feafe53]
 description = "find the largest palindrome from double digit factors"
-include = true
 
 [cecb5a35-46d1-4666-9719-fa2c3af7499d]
 description = "find smallest palindrome from triple digit factors"
-include = true
 
 [edab43e1-c35f-4ea3-8c55-2f31dddd92e5]
 description = "find the largest palindrome from triple digit factors"
-include = true
 
 [4f802b5a-9d74-4026-a70f-b53ff9234e4e]
 description = "find smallest palindrome from four digit factors"
-include = true
 
 [787525e0-a5f9-40f3-8cb2-23b52cf5d0be]
 description = "find the largest palindrome from four digit factors"
-include = true
 
 [58fb1d63-fddb-4409-ab84-a7a8e58d9ea0]
 description = "empty result for smallest if no palindrome in the range"
-include = true
 
 [9de9e9da-f1d9-49a5-8bfc-3d322efbdd02]
 description = "empty result for largest if no palindrome in the range"
-include = true
 
 [12e73aac-d7ee-4877-b8aa-2aa3dcdb9f8a]
 description = "error result for smallest if min is more than max"
-include = true
 
 [eeeb5bff-3f47-4b1e-892f-05829277bd74]
 description = "error result for largest if min is more than max"
-include = true

--- a/exercises/practice/pangram/.meta/tests.toml
+++ b/exercises/practice/pangram/.meta/tests.toml
@@ -4,40 +4,30 @@
 
 [64f61791-508e-4f5c-83ab-05de042b0149]
 description = "empty sentence"
-include = true
 
 [74858f80-4a4d-478b-8a5e-c6477e4e4e84]
 description = "perfect lower case"
-include = true
 
 [61288860-35ca-4abe-ba08-f5df76ecbdcd]
 description = "only lower case"
-include = true
 
 [6564267d-8ac5-4d29-baf2-e7d2e304a743]
 description = "missing the letter 'x'"
-include = true
 
 [c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0]
 description = "missing the letter 'h'"
-include = true
 
 [d835ec38-bc8f-48e4-9e36-eb232427b1df]
 description = "with underscores"
-include = true
 
 [8cc1e080-a178-4494-b4b3-06982c9be2a8]
 description = "with numbers"
-include = true
 
 [bed96b1c-ff95-45b8-9731-fdbdcb6ede9a]
 description = "missing letters replaced by numbers"
-include = true
 
 [938bd5d8-ade5-40e2-a2d9-55a338a01030]
 description = "mixed case and punctuation"
-include = true
 
 [2577bf54-83c8-402d-a64b-a2c0f7bb213a]
 description = "case insensitive"
-include = true

--- a/exercises/practice/pascals-triangle/.meta/tests.toml
+++ b/exercises/practice/pascals-triangle/.meta/tests.toml
@@ -4,32 +4,24 @@
 
 [9920ce55-9629-46d5-85d6-4201f4a4234d]
 description = "zero rows"
-include = true
 
 [70d643ce-a46d-4e93-af58-12d88dd01f21]
 description = "single row"
-include = true
 
 [a6e5a2a2-fc9a-4b47-9f4f-ed9ad9fbe4bd]
 description = "two rows"
-include = true
 
 [97206a99-79ba-4b04-b1c5-3c0fa1e16925]
 description = "three rows"
-include = true
 
 [565a0431-c797-417c-a2c8-2935e01ce306]
 description = "four rows"
-include = true
 
 [06f9ea50-9f51-4eb2-b9a9-c00975686c27]
 description = "five rows"
-include = true
 
 [c3912965-ddb4-46a9-848e-3363e6b00b13]
 description = "six rows"
-include = true
 
 [6cb26c66-7b57-4161-962c-81ec8c99f16b]
 description = "ten rows"
-include = true

--- a/exercises/practice/perfect-numbers/.meta/tests.toml
+++ b/exercises/practice/perfect-numbers/.meta/tests.toml
@@ -4,52 +4,39 @@
 
 [163e8e86-7bfd-4ee2-bd68-d083dc3381a3]
 description = "Smallest perfect number is classified correctly"
-include = true
 
 [169a7854-0431-4ae0-9815-c3b6d967436d]
 description = "Medium perfect number is classified correctly"
-include = true
 
 [ee3627c4-7b36-4245-ba7c-8727d585f402]
 description = "Large perfect number is classified correctly"
-include = true
 
 [80ef7cf8-9ea8-49b9-8b2d-d9cb3db3ed7e]
 description = "Smallest abundant number is classified correctly"
-include = true
 
 [3e300e0d-1a12-4f11-8c48-d1027165ab60]
 description = "Medium abundant number is classified correctly"
-include = true
 
 [ec7792e6-8786-449c-b005-ce6dd89a772b]
 description = "Large abundant number is classified correctly"
-include = true
 
 [e610fdc7-2b6e-43c3-a51c-b70fb37413ba]
 description = "Smallest prime deficient number is classified correctly"
-include = true
 
 [0beb7f66-753a-443f-8075-ad7fbd9018f3]
 description = "Smallest non-prime deficient number is classified correctly"
-include = true
 
 [1c802e45-b4c6-4962-93d7-1cad245821ef]
 description = "Medium deficient number is classified correctly"
-include = true
 
 [47dd569f-9e5a-4a11-9a47-a4e91c8c28aa]
 description = "Large deficient number is classified correctly"
-include = true
 
 [a696dec8-6147-4d68-afad-d38de5476a56]
 description = "Edge case (no factors other than itself) is classified correctly"
-include = true
 
 [72445cee-660c-4d75-8506-6c40089dc302]
 description = "Zero is rejected (not a natural number)"
-include = true
 
 [2d72ce2c-6802-49ac-8ece-c790ba3dae13]
 description = "Negative integer is rejected (not a natural number)"
-include = true

--- a/exercises/practice/poker/.meta/tests.toml
+++ b/exercises/practice/poker/.meta/tests.toml
@@ -4,112 +4,84 @@
 
 [161f485e-39c2-4012-84cf-bec0c755b66c]
 description = "single hand always wins"
-include = true
 
 [370ac23a-a00f-48a9-9965-6f3fb595cf45]
 description = "highest card out of all hands wins"
-include = true
 
 [d94ad5a7-17df-484b-9932-c64fc26cff52]
 description = "a tie has multiple winners"
-include = true
 
 [61ed83a9-cfaa-40a5-942a-51f52f0a8725]
 description = "multiple hands with the same high cards, tie compares next highest ranked, down to last card"
-include = true
 
 [f7175a89-34ff-44de-b3d7-f6fd97d1fca4]
 description = "one pair beats high card"
-include = true
 
 [e114fd41-a301-4111-a9e7-5a7f72a76561]
 description = "highest pair wins"
-include = true
 
 [935bb4dc-a622-4400-97fa-86e7d06b1f76]
 description = "two pairs beats one pair"
-include = true
 
 [c8aeafe1-6e3d-4711-a6de-5161deca91fd]
 description = "both hands have two pairs, highest ranked pair wins"
-include = true
 
 [88abe1ba-7ad7-40f3-847e-0a26f8e46a60]
 description = "both hands have two pairs, with the same highest ranked pair, tie goes to low pair"
-include = true
 
 [15a7a315-0577-47a3-9981-d6cf8e6f387b]
 description = "both hands have two identically ranked pairs, tie goes to remaining card (kicker)"
-include = true
 
 [21e9f1e6-2d72-49a1-a930-228e5e0195dc]
 description = "three of a kind beats two pair"
-include = true
 
 [c2fffd1f-c287-480f-bf2d-9628e63bbcc3]
 description = "both hands have three of a kind, tie goes to highest ranked triplet"
-include = true
 
 [eb856cc2-481c-4b0d-9835-4d75d07a5d9d]
 description = "with multiple decks, two players can have same three of a kind, ties go to highest remaining cards"
-include = true
 
 [a858c5d9-2f28-48e7-9980-b7fa04060a60]
 description = "a straight beats three of a kind"
-include = true
 
 [73c9c756-e63e-4b01-a88d-0d4491a7a0e3]
 description = "aces can end a straight (10 J Q K A)"
-include = true
 
 [76856b0d-35cd-49ce-a492-fe5db53abc02]
 description = "aces can start a straight (A 2 3 4 5)"
-include = true
 
 [6980c612-bbff-4914-b17a-b044e4e69ea1]
 description = "both hands with a straight, tie goes to highest ranked card"
-include = true
 
 [5135675c-c2fc-4e21-9ba3-af77a32e9ba4]
 description = "even though an ace is usually high, a 5-high straight is the lowest-scoring straight"
-include = true
 
 [c601b5e6-e1df-4ade-b444-b60ce13b2571]
 description = "flush beats a straight"
-include = true
 
 [4d90261d-251c-49bd-a468-896bf10133de]
 description = "both hands have a flush, tie goes to high card, down to the last one if necessary"
-include = true
 
 [3a19361d-8974-455c-82e5-f7152f5dba7c]
 description = "full house beats a flush"
-include = true
 
 [eb73d0e6-b66c-4f0f-b8ba-bf96bc0a67f0]
 description = "both hands have a full house, tie goes to highest-ranked triplet"
-include = true
 
 [34b51168-1e43-4c0d-9b32-e356159b4d5d]
 description = "with multiple decks, both hands have a full house with the same triplet, tie goes to the pair"
-include = true
 
 [d61e9e99-883b-4f99-b021-18f0ae50c5f4]
 description = "four of a kind beats a full house"
-include = true
 
 [2e1c8c63-e0cb-4214-a01b-91954490d2fe]
 description = "both hands have four of a kind, tie goes to high quad"
-include = true
 
 [892ca75d-5474-495d-9f64-a6ce2dcdb7e1]
 description = "with multiple decks, both hands with identical four of a kind, tie determined by kicker"
-include = true
 
 [923bd910-dc7b-4f7d-a330-8b42ec10a3ac]
 description = "straight flush beats four of a kind"
-include = true
 
 [d0927f70-5aec-43db-aed8-1cbd1b6ee9ad]
 description = "both hands have straight flush, tie goes to highest-ranked card"
-include = true

--- a/exercises/practice/prime-factors/.meta/tests.toml
+++ b/exercises/practice/prime-factors/.meta/tests.toml
@@ -4,48 +4,36 @@
 
 [924fc966-a8f5-4288-82f2-6b9224819ccd]
 description = "no factors"
-include = true
 
 [17e30670-b105-4305-af53-ddde182cb6ad]
 description = "prime number"
-include = true
 
 [238d57c8-4c12-42ef-af34-ae4929f94789]
 description = "another prime number"
-include = true
 
 [f59b8350-a180-495a-8fb1-1712fbee1158]
 description = "square of a prime"
-include = true
 
 [756949d3-3158-4e3d-91f2-c4f9f043ee70]
 description = "product of first prime"
-include = true
 
 [bc8c113f-9580-4516-8669-c5fc29512ceb]
 description = "cube of a prime"
-include = true
 
 [7d6a3300-a4cb-4065-bd33-0ced1de6cb44]
 description = "product of second prime"
-include = true
 
 [073ac0b2-c915-4362-929d-fc45f7b9a9e4]
 description = "product of a thirf prime"
-include = true
 
 [6e0e4912-7fb6-47f3-a9ad-dbcd79340c75]
 description = "product of first and second prime"
-include = true
 
 [00485cd3-a3fe-4fbe-a64a-a4308fc1f870]
 description = "product of primes and non-primes"
-include = true
 
 [02251d54-3ca1-4a9b-85e1-b38f4b0ccb91]
 description = "product of primes"
-include = true
 
 [070cf8dc-e202-4285-aa37-8d775c9cd473]
 description = "factors include a large prime"
-include = true

--- a/exercises/practice/protein-translation/.meta/tests.toml
+++ b/exercises/practice/protein-translation/.meta/tests.toml
@@ -4,92 +4,69 @@
 
 [96d3d44f-34a2-4db4-84cd-fff523e069be]
 description = "Methionine RNA sequence"
-include = true
 
 [1b4c56d8-d69f-44eb-be0e-7b17546143d9]
 description = "Phenylalanine RNA sequence 1"
-include = true
 
 [81b53646-bd57-4732-b2cb-6b1880e36d11]
 description = "Phenylalanine RNA sequence 2"
-include = true
 
 [42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4]
 description = "Leucine RNA sequence 1"
-include = true
 
 [ac5edadd-08ed-40a3-b2b9-d82bb50424c4]
 description = "Leucine RNA sequence 2"
-include = true
 
 [8bc36e22-f984-44c3-9f6b-ee5d4e73f120]
 description = "Serine RNA sequence 1"
-include = true
 
 [5c3fa5da-4268-44e5-9f4b-f016ccf90131]
 description = "Serine RNA sequence 2"
-include = true
 
 [00579891-b594-42b4-96dc-7ff8bf519606]
 description = "Serine RNA sequence 3"
-include = true
 
 [08c61c3b-fa34-4950-8c4a-133945570ef6]
 description = "Serine RNA sequence 4"
-include = true
 
 [54e1e7d8-63c0-456d-91d2-062c72f8eef5]
 description = "Tyrosine RNA sequence 1"
-include = true
 
 [47bcfba2-9d72-46ad-bbce-22f7666b7eb1]
 description = "Tyrosine RNA sequence 2"
-include = true
 
 [3a691829-fe72-43a7-8c8e-1bd083163f72]
 description = "Cysteine RNA sequence 1"
-include = true
 
 [1b6f8a26-ca2f-43b8-8262-3ee446021767]
 description = "Cysteine RNA sequence 2"
-include = true
 
 [1e91c1eb-02c0-48a0-9e35-168ad0cb5f39]
 description = "Tryptophan RNA sequence"
-include = true
 
 [e547af0b-aeab-49c7-9f13-801773a73557]
 description = "STOP codon RNA sequence 1"
-include = true
 
 [67640947-ff02-4f23-a2ef-816f8a2ba72e]
 description = "STOP codon RNA sequence 2"
-include = true
 
 [9c2ad527-ebc9-4ace-808b-2b6447cb54cb]
 description = "STOP codon RNA sequence 3"
-include = true
 
 [d0f295df-fb70-425c-946c-ec2ec185388e]
 description = "Translate RNA strand into correct protein list"
-include = true
 
 [e30e8505-97ec-4e5f-a73e-5726a1faa1f4]
 description = "Translation stops if STOP codon at beginning of sequence"
-include = true
 
 [5358a20b-6f4c-4893-bce4-f929001710f3]
 description = "Translation stops if STOP codon at end of two-codon sequence"
-include = true
 
 [ba16703a-1a55-482f-bb07-b21eef5093a3]
 description = "Translation stops if STOP codon at end of three-codon sequence"
-include = true
 
 [4089bb5a-d5b4-4e71-b79e-b8d1f14a2911]
 description = "Translation stops if STOP codon in middle of three-codon sequence"
-include = true
 
 [2c2a2a60-401f-4a80-b977-e0715b23b93d]
 description = "Translation stops if STOP codon in middle of six-codon sequence"
-include = true

--- a/exercises/practice/pythagorean-triplet/.meta/tests.toml
+++ b/exercises/practice/pythagorean-triplet/.meta/tests.toml
@@ -4,28 +4,21 @@
 
 [a19de65d-35b8-4480-b1af-371d9541e706]
 description = "triplets whose sum is 12"
-include = true
 
 [48b21332-0a3d-43b2-9a52-90b2a6e5c9f5]
 description = "triplets whose sum is 108"
-include = true
 
 [dffc1266-418e-4daa-81af-54c3e95c3bb5]
 description = "triplets whose sum is 1000"
-include = true
 
 [5f86a2d4-6383-4cce-93a5-e4489e79b186]
 description = "no matching triplets for 1001"
-include = true
 
 [bf17ba80-1596-409a-bb13-343bdb3b2904]
 description = "returns all matching triplets"
-include = true
 
 [9d8fb5d5-6c6f-42df-9f95-d3165963ac57]
 description = "several matching triplets"
-include = true
 
 [f5be5734-8aa0-4bd1-99a2-02adcc4402b4]
 description = "triplets for large number"
-include = true

--- a/exercises/practice/queen-attack/.meta/tests.toml
+++ b/exercises/practice/queen-attack/.meta/tests.toml
@@ -4,48 +4,36 @@
 
 [3ac4f735-d36c-44c4-a3e2-316f79704203]
 description = "queen with a valid position"
-include = true
 
 [4e812d5d-b974-4e38-9a6b-8e0492bfa7be]
 description = "queen must have positive row"
-include = true
 
 [f07b7536-b66b-4f08-beb9-4d70d891d5c8]
 description = "queen must have row on board"
-include = true
 
 [15a10794-36d9-4907-ae6b-e5a0d4c54ebe]
 description = "queen must have positive column"
-include = true
 
 [6907762d-0e8a-4c38-87fb-12f2f65f0ce4]
 description = "queen must have column on board"
-include = true
 
 [33ae4113-d237-42ee-bac1-e1e699c0c007]
 description = "can not attack"
-include = true
 
 [eaa65540-ea7c-4152-8c21-003c7a68c914]
 description = "can attack on same row"
-include = true
 
 [bae6f609-2c0e-4154-af71-af82b7c31cea]
 description = "can attack on same column"
-include = true
 
 [0e1b4139-b90d-4562-bd58-dfa04f1746c7]
 description = "can attack on first diagonal"
-include = true
 
 [ff9b7ed4-e4b6-401b-8d16-bc894d6d3dcd]
 description = "can attack on second diagonal"
-include = true
 
 [0a71e605-6e28-4cc2-aa47-d20a2e71037a]
 description = "can attack on third diagonal"
-include = true
 
 [0790b588-ae73-4f1f-a968-dd0b34f45f86]
 description = "can attack on fourth diagonal"
-include = true

--- a/exercises/practice/rail-fence-cipher/.meta/tests.toml
+++ b/exercises/practice/rail-fence-cipher/.meta/tests.toml
@@ -4,24 +4,18 @@
 
 [46dc5c50-5538-401d-93a5-41102680d068]
 description = "encode with two rails"
-include = true
 
 [25691697-fbd8-4278-8c38-b84068b7bc29]
 description = "encode with three rails"
-include = true
 
 [384f0fea-1442-4f1a-a7c4-5cbc2044002c]
 description = "encode with ending in the middle"
-include = true
 
 [cd525b17-ec34-45ef-8f0e-4f27c24a7127]
 description = "decode with three rails"
-include = true
 
 [dd7b4a98-1a52-4e5c-9499-cbb117833507]
 description = "decode with five rails"
-include = true
 
 [93e1ecf4-fac9-45d9-9cd2-591f47d3b8d3]
 description = "decode with six rails"
-include = true

--- a/exercises/practice/raindrops/.meta/tests.toml
+++ b/exercises/practice/raindrops/.meta/tests.toml
@@ -4,72 +4,54 @@
 
 [1575d549-e502-46d4-a8e1-6b7bec6123d8]
 description = "the sound for 1 is 1"
-include = true
 
 [1f51a9f9-4895-4539-b182-d7b0a5ab2913]
 description = "the sound for 3 is Pling"
-include = true
 
 [2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0]
 description = "the sound for 5 is Plang"
-include = true
 
 [d7e60daa-32ef-4c23-b688-2abff46c4806]
 description = "the sound for 7 is Plong"
-include = true
 
 [6bb4947b-a724-430c-923f-f0dc3d62e56a]
 description = "the sound for 6 is Pling as it has a factor 3"
-include = true
 
 [ce51e0e8-d9d4-446d-9949-96eac4458c2d]
 description = "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base"
-include = true
 
 [0dd66175-e3e2-47fc-8750-d01739856671]
 description = "the sound for 9 is Pling as it has a factor 3"
-include = true
 
 [022c44d3-2182-4471-95d7-c575af225c96]
 description = "the sound for 10 is Plang as it has a factor 5"
-include = true
 
 [37ab74db-fed3-40ff-b7b9-04acdfea8edf]
 description = "the sound for 14 is Plong as it has a factor of 7"
-include = true
 
 [31f92999-6afb-40ee-9aa4-6d15e3334d0f]
 description = "the sound for 15 is PlingPlang as it has factors 3 and 5"
-include = true
 
 [ff9bb95d-6361-4602-be2c-653fe5239b54]
 description = "the sound for 21 is PlingPlong as it has factors 3 and 7"
-include = true
 
 [d2e75317-b72e-40ab-8a64-6734a21dece1]
 description = "the sound for 25 is Plang as it has a factor 5"
-include = true
 
 [a09c4c58-c662-4e32-97fe-f1501ef7125c]
 description = "the sound for 27 is Pling as it has a factor 3"
-include = true
 
 [bdf061de-8564-4899-a843-14b48b722789]
 description = "the sound for 35 is PlangPlong as it has factors 5 and 7"
-include = true
 
 [c4680bee-69ba-439d-99b5-70c5fd1a7a83]
 description = "the sound for 49 is Plong as it has a factor 7"
-include = true
 
 [17f2bc9a-b65a-4d23-8ccd-266e8c271444]
 description = "the sound for 52 is 52"
-include = true
 
 [e46677ed-ff1a-419f-a740-5c713d2830e4]
 description = "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7"
-include = true
 
 [13c6837a-0fcd-4b86-a0eb-20572f7deb0b]
 description = "the sound for 3125 is Plang as it has a factor 5"
-include = true

--- a/exercises/practice/rational-numbers/.meta/tests.toml
+++ b/exercises/practice/rational-numbers/.meta/tests.toml
@@ -4,152 +4,114 @@
 
 [0ba4d988-044c-4ed5-9215-4d0bb8d0ae9f]
 description = "Add two positive rational numbers"
-include = true
 
 [88ebc342-a2ac-4812-a656-7b664f718b6a]
 description = "Add a positive rational number and a negative rational number"
-include = true
 
 [92ed09c2-991e-4082-a602-13557080205c]
 description = "Add two negative rational numbers"
-include = true
 
 [6e58999e-3350-45fb-a104-aac7f4a9dd11]
 description = "Add a rational number to its additive inverse"
-include = true
 
 [47bba350-9db1-4ab9-b412-4a7e1f72a66e]
 description = "Subtract two positive rational numbers"
-include = true
 
 [93926e2a-3e82-4aee-98a7-fc33fb328e87]
 description = "Subtract a positive rational number and a negative rational number"
-include = true
 
 [a965ba45-9b26-442b-bdc7-7728e4b8d4cc]
 description = "Subtract two negative rational numbers"
-include = true
 
 [0df0e003-f68e-4209-8c6e-6a4e76af5058]
 description = "Subtract a rational number from itself"
-include = true
 
 [34fde77a-75f4-4204-8050-8d3a937958d3]
 description = "Multiply two positive rational numbers"
-include = true
 
 [6d015cf0-0ea3-41f1-93de-0b8e38e88bae]
 description = "Multiply a negative rational number by a positive rational number"
-include = true
 
 [d1bf1b55-954e-41b1-8c92-9fc6beeb76fa]
 description = "Multiply two negative rational numbers"
-include = true
 
 [a9b8f529-9ec7-4c79-a517-19365d779040]
 description = "Multiply a rational number by its reciprocal"
-include = true
 
 [d89d6429-22fa-4368-ab04-9e01a44d3b48]
 description = "Multiply a rational number by 1"
-include = true
 
 [0d95c8b9-1482-4ed7-bac9-b8694fa90145]
 description = "Multiply a rational number by 0"
-include = true
 
 [1de088f4-64be-4e6e-93fd-5997ae7c9798]
 description = "Divide two positive rational numbers"
-include = true
 
 [7d7983db-652a-4e66-981a-e921fb38d9a9]
 description = "Divide a positive rational number by a negative rational number"
-include = true
 
 [1b434d1b-5b38-4cee-aaf5-b9495c399e34]
 description = "Divide two negative rational numbers"
-include = true
 
 [d81c2ebf-3612-45a6-b4e0-f0d47812bd59]
 description = "Divide a rational number by 1"
-include = true
 
 [5fee0d8e-5955-4324-acbe-54cdca94ddaa]
 description = "Absolute value of a positive rational number"
-include = true
 
 [3cb570b6-c36a-4963-a380-c0834321bcaa]
 description = "Absolute value of a positive rational number with negative numerator and denominator"
-include = true
 
 [6a05f9a0-1f6b-470b-8ff7-41af81773f25]
 description = "Absolute value of a negative rational number"
-include = true
 
 [5d0f2336-3694-464f-8df9-f5852fda99dd]
 description = "Absolute value of a negative rational number with negative denominator"
-include = true
 
 [f8e1ed4b-9dca-47fb-a01e-5311457b3118]
 description = "Absolute value of zero"
-include = true
 
 [ea2ad2af-3dab-41e7-bb9f-bd6819668a84]
 description = "Raise a positive rational number to a positive integer power"
-include = true
 
 [8168edd2-0af3-45b1-b03f-72c01332e10a]
 description = "Raise a negative rational number to a positive integer power"
-include = true
 
 [e2f25b1d-e4de-4102-abc3-c2bb7c4591e4]
 description = "Raise zero to an integer power"
-include = true
 
 [431cac50-ab8b-4d58-8e73-319d5404b762]
 description = "Raise one to an integer power"
-include = true
 
 [7d164739-d68a-4a9c-b99f-dd77ce5d55e6]
 description = "Raise a positive rational number to the power of zero"
-include = true
 
 [eb6bd5f5-f880-4bcd-8103-e736cb6e41d1]
 description = "Raise a negative rational number to the power of zero"
-include = true
 
 [30b467dd-c158-46f5-9ffb-c106de2fd6fa]
 description = "Raise a real number to a positive rational number"
-include = true
 
 [6e026bcc-be40-4b7b-ae22-eeaafc5a1789]
 description = "Raise a real number to a negative rational number"
-include = true
 
 [9f866da7-e893-407f-8cd2-ee85d496eec5]
 description = "Raise a real number to a zero rational number"
-include = true
 
 [0a63fbde-b59c-4c26-8237-1e0c73354d0a]
 description = "Reduce a positive rational number to lowest terms"
-include = true
 
 [f87c2a4e-d29c-496e-a193-318c503e4402]
 description = "Reduce a negative rational number to lowest terms"
-include = true
 
 [3b92ffc0-5b70-4a43-8885-8acee79cdaaf]
 description = "Reduce a rational number with a negative denominator to lowest terms"
-include = true
 
 [c9dbd2e6-5ac0-4a41-84c1-48b645b4f663]
 description = "Reduce zero to lowest terms"
-include = true
 
 [297b45ad-2054-4874-84d4-0358dc1b8887]
 description = "Reduce an integer to lowest terms"
-include = true
 
 [a73a17fe-fe8c-4a1c-a63b-e7579e333d9e]
 description = "Reduce one to lowest terms"
-include = true

--- a/exercises/practice/rna-transcription/.meta/tests.toml
+++ b/exercises/practice/rna-transcription/.meta/tests.toml
@@ -4,24 +4,18 @@
 
 [b4631f82-c98c-4a2f-90b3-c5c2b6c6f661]
 description = "Empty RNA sequence"
-include = true
 
 [a9558a3c-318c-4240-9256-5d5ed47005a6]
 description = "RNA complement of cytosine is guanine"
-include = true
 
 [6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7]
 description = "RNA complement of guanine is cytosine"
-include = true
 
 [870bd3ec-8487-471d-8d9a-a25046488d3e]
 description = "RNA complement of thymine is adenine"
-include = true
 
 [aade8964-02e1-4073-872f-42d3ffd74c5f]
 description = "RNA complement of adenine is uracil"
-include = true
 
 [79ed2757-f018-4f47-a1d7-34a559392dbf]
 description = "RNA complement"
-include = true

--- a/exercises/practice/robot-simulator/.meta/tests.toml
+++ b/exercises/practice/robot-simulator/.meta/tests.toml
@@ -4,72 +4,54 @@
 
 [c557c16d-26c1-4e06-827c-f6602cd0785c]
 description = "at origin facing north"
-include = true
 
 [bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d]
 description = "at negative position facing south"
-include = true
 
 [8cbd0086-6392-4680-b9b9-73cf491e67e5]
 description = "changes north to east"
-include = true
 
 [8abc87fc-eab2-4276-93b7-9c009e866ba1]
 description = "changes east to south"
-include = true
 
 [3cfe1b85-bbf2-4bae-b54d-d73e7e93617a]
 description = "changes south to west"
-include = true
 
 [5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716]
 description = "changes west to north"
-include = true
 
 [fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63]
 description = "changes north to west"
-include = true
 
 [da33d734-831f-445c-9907-d66d7d2a92e2]
 description = "changes west to south"
-include = true
 
 [bd1ca4b9-4548-45f4-b32e-900fc7c19389]
 description = "changes south to east"
-include = true
 
 [2de27b67-a25c-4b59-9883-bc03b1b55bba]
 description = "changes east to north"
-include = true
 
 [f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8]
 description = "facing north increments Y"
-include = true
 
 [2786cf80-5bbf-44b0-9503-a89a9c5789da]
 description = "facing south decrements Y"
-include = true
 
 [84bf3c8c-241f-434d-883d-69817dbd6a48]
 description = "facing east increments X"
-include = true
 
 [bb69c4a7-3bbf-4f64-b415-666fa72d7b04]
 description = "facing west decrements X"
-include = true
 
 [e34ac672-4ed4-4be3-a0b8-d9af259cbaa1]
 description = "moving east and north from README"
-include = true
 
 [f30e4955-4b47-4aa3-8b39-ae98cfbd515b]
 description = "moving west and north"
-include = true
 
 [3e466bf6-20ab-4d79-8b51-264165182fca]
 description = "moving west and south"
-include = true
 
 [41f0bb96-c617-4e6b-acff-a4b279d44514]
 description = "moving east and north"
-include = true

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -4,76 +4,57 @@
 
 [19828a3a-fbf7-4661-8ddd-cbaeee0e2178]
 description = "1 is a single I"
-include = true
 
 [f088f064-2d35-4476-9a41-f576da3f7b03]
 description = "2 is two I's"
-include = true
 
 [b374a79c-3bea-43e6-8db8-1286f79c7106]
 description = "3 is three I's"
-include = true
 
 [05a0a1d4-a140-4db1-82e8-fcc21fdb49bb]
 description = "4, being 5 - 1, is IV"
-include = true
 
 [57c0f9ad-5024-46ab-975d-de18c430b290]
 description = "5 is a single V"
-include = true
 
 [20a2b47f-e57f-4797-a541-0b3825d7f249]
 description = "6, being 5 + 1, is VI"
-include = true
 
 [ff3fb08c-4917-4aab-9f4e-d663491d083d]
 description = "9, being 10 - 1, is IX"
-include = true
 
 [2bda64ca-7d28-4c56-b08d-16ce65716cf6]
 description = "20 is two X's"
-include = true
 
 [a1f812ef-84da-4e02-b4f0-89c907d0962c]
 description = "48 is not 50 - 2 but rather 40 + 8"
-include = true
 
 [607ead62-23d6-4c11-a396-ef821e2e5f75]
 description = "49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1"
-include = true
 
 [d5b283d4-455d-4e68-aacf-add6c4b51915]
 description = "50 is a single L"
-include = true
 
 [46b46e5b-24da-4180-bfe2-2ef30b39d0d0]
 description = "90, being 100 - 10, is XC"
-include = true
 
 [30494be1-9afb-4f84-9d71-db9df18b55e3]
 description = "100 is a single C"
-include = true
 
 [267f0207-3c55-459a-b81d-67cec7a46ed9]
 description = "60, being 50 + 10, is LX"
-include = true
 
 [cdb06885-4485-4d71-8bfb-c9d0f496b404]
 description = "400, being 500 - 100, is CD"
-include = true
 
 [6b71841d-13b2-46b4-ba97-dec28133ea80]
 description = "500 is a single D"
-include = true
 
 [432de891-7fd6-4748-a7f6-156082eeca2f]
 description = "900, being 1000 - 100, is CM"
-include = true
 
 [e6de6d24-f668-41c0-88d7-889c0254d173]
 description = "1000 is a single M"
-include = true
 
 [bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
 description = "3000 is three M's"
-include = true

--- a/exercises/practice/rotational-cipher/.meta/tests.toml
+++ b/exercises/practice/rotational-cipher/.meta/tests.toml
@@ -4,40 +4,30 @@
 
 [74e58a38-e484-43f1-9466-877a7515e10f]
 description = "rotate a by 0, same output as input"
-include = true
 
 [7ee352c6-e6b0-4930-b903-d09943ecb8f5]
 description = "rotate a by 1"
-include = true
 
 [edf0a733-4231-4594-a5ee-46a4009ad764]
 description = "rotate a by 26, same output as input"
-include = true
 
 [e3e82cb9-2a5b-403f-9931-e43213879300]
 description = "rotate m by 13"
-include = true
 
 [19f9eb78-e2ad-4da4-8fe3-9291d47c1709]
 description = "rotate n by 13 with wrap around alphabet"
-include = true
 
 [a116aef4-225b-4da9-884f-e8023ca6408a]
 description = "rotate capital letters"
-include = true
 
 [71b541bb-819c-4dc6-a9c3-132ef9bb737b]
 description = "rotate spaces"
-include = true
 
 [ef32601d-e9ef-4b29-b2b5-8971392282e6]
 description = "rotate numbers"
-include = true
 
 [32dd74f6-db2b-41a6-b02c-82eb4f93e549]
 description = "rotate punctuation"
-include = true
 
 [9fb93fe6-42b0-46e6-9ec1-0bf0a062d8c9]
 description = "rotate all letters"
-include = true

--- a/exercises/practice/run-length-encoding/.meta/tests.toml
+++ b/exercises/practice/run-length-encoding/.meta/tests.toml
@@ -4,52 +4,39 @@
 
 [ad53b61b-6ffc-422f-81a6-61f7df92a231]
 description = "empty string"
-include = true
 
 [52012823-b7e6-4277-893c-5b96d42f82de]
 description = "single characters only are encoded without count"
-include = true
 
 [b7868492-7e3a-415f-8da3-d88f51f80409]
 description = "string with no single characters"
-include = true
 
 [859b822b-6e9f-44d6-9c46-6091ee6ae358]
 description = "single characters mixed with repeated characters"
-include = true
 
 [1b34de62-e152-47be-bc88-469746df63b3]
 description = "multiple whitespace mixed in string"
-include = true
 
 [abf176e2-3fbd-40ad-bb2f-2dd6d4df721a]
 description = "lowercase characters"
-include = true
 
 [7ec5c390-f03c-4acf-ac29-5f65861cdeb5]
 description = "empty string"
-include = true
 
 [ad23f455-1ac2-4b0e-87d0-b85b10696098]
 description = "single characters only"
-include = true
 
 [21e37583-5a20-4a0e-826c-3dee2c375f54]
 description = "string with no single characters"
-include = true
 
 [1389ad09-c3a8-4813-9324-99363fba429c]
 description = "single characters with repeated characters"
-include = true
 
 [3f8e3c51-6aca-4670-b86c-a213bf4706b0]
 description = "multiple whitespace mixed in string"
-include = true
 
 [29f721de-9aad-435f-ba37-7662df4fb551]
 description = "lower case string"
-include = true
 
 [2a762efd-8695-4e04-b0d6-9736899fbc16]
 description = "encode followed by decode gives original string"
-include = true

--- a/exercises/practice/satellite/.meta/tests.toml
+++ b/exercises/practice/satellite/.meta/tests.toml
@@ -4,24 +4,18 @@
 
 [8df3fa26-811a-4165-9286-ff9ac0850d19]
 description = "Empty tree"
-include = true
 
 [f945ccfc-05e3-47d7-825b-0270559d43ad]
 description = "Tree with one item"
-include = true
 
 [a0121d5f-37b0-48dd-9c64-cba4c4464135]
 description = "Tree with many items"
-include = true
 
 [6074041f-4891-4d81-a128-401050c2a3b0]
 description = "Reject traversals of different length"
-include = true
 
 [27916ce4-45f3-4d8b-8528-496fedc157ca]
 description = "Reject inconsistent traversals of same length"
-include = true
 
 [d86a3d72-76a9-43b5-9d3a-e64cb1216035]
 description = "Reject traversals with repeated items"
-include = true

--- a/exercises/practice/scrabble-score/.meta/tests.toml
+++ b/exercises/practice/scrabble-score/.meta/tests.toml
@@ -4,44 +4,33 @@
 
 [f46cda29-1ca5-4ef2-bd45-388a767e3db2]
 description = "lowercase letter"
-include = true
 
 [f7794b49-f13e-45d1-a933-4e48459b2201]
 description = "uppercase letter"
-include = true
 
 [eaba9c76-f9fa-49c9-a1b0-d1ba3a5b31fa]
 description = "valuable letter"
-include = true
 
 [f3c8c94e-bb48-4da2-b09f-e832e103151e]
 description = "short word"
-include = true
 
 [71e3d8fa-900d-4548-930e-68e7067c4615]
 description = "short, valuable word"
-include = true
 
 [d3088ad9-570c-4b51-8764-c75d5a430e99]
 description = "medium word"
-include = true
 
 [fa20c572-ad86-400a-8511-64512daac352]
 description = "medium, valuable word"
-include = true
 
 [9336f0ba-9c2b-4fa0-bd1c-2e2d328cf967]
 description = "long, mixed-case word"
-include = true
 
 [1e34e2c3-e444-4ea7-b598-3c2b46fd2c10]
 description = "english-like word"
-include = true
 
 [4efe3169-b3b6-4334-8bae-ff4ef24a7e4f]
 description = "empty input"
-include = true
 
 [3b305c1c-f260-4e15-a5b5-cb7d3ea7c3d7]
 description = "entire alphabet available"
-include = true

--- a/exercises/practice/secret-handshake/.meta/tests.toml
+++ b/exercises/practice/secret-handshake/.meta/tests.toml
@@ -4,44 +4,33 @@
 
 [b8496fbd-6778-468c-8054-648d03c4bb23]
 description = "wink for 1"
-include = true
 
 [83ec6c58-81a9-4fd1-bfaf-0160514fc0e3]
 description = "double blink for 10"
-include = true
 
 [0e20e466-3519-4134-8082-5639d85fef71]
 description = "close your eyes for 100"
-include = true
 
 [b339ddbb-88b7-4b7d-9b19-4134030d9ac0]
 description = "jump for 1000"
-include = true
 
 [40499fb4-e60c-43d7-8b98-0de3ca44e0eb]
 description = "combine two actions"
-include = true
 
 [9730cdd5-ef27-494b-afd3-5c91ad6c3d9d]
 description = "reverse two actions"
-include = true
 
 [0b828205-51ca-45cd-90d5-f2506013f25f]
 description = "reversing one action gives the same action"
-include = true
 
 [9949e2ac-6c9c-4330-b685-2089ab28b05f]
 description = "reversing no actions still gives no actions"
-include = true
 
 [23fdca98-676b-4848-970d-cfed7be39f81]
 description = "all possible actions"
-include = true
 
 [ae8fe006-d910-4d6f-be00-54b7c3799e79]
 description = "reverse all possible actions"
-include = true
 
 [3d36da37-b31f-4cdb-a396-d93a2ee1c4a5]
 description = "do nothing for zero"
-include = true

--- a/exercises/practice/series/.meta/tests.toml
+++ b/exercises/practice/series/.meta/tests.toml
@@ -4,40 +4,30 @@
 
 [7ae7a46a-d992-4c2a-9c15-a112d125ebad]
 description = "slices of one from one"
-include = true
 
 [3143b71d-f6a5-4221-aeae-619f906244d2]
 description = "slices of one from two"
-include = true
 
 [dbb68ff5-76c5-4ccd-895a-93dbec6d5805]
 description = "slices of two"
-include = true
 
 [19bbea47-c987-4e11-a7d1-e103442adf86]
 description = "slices of two overlap"
-include = true
 
 [8e17148d-ba0a-4007-a07f-d7f87015d84c]
 description = "slices can include duplicates"
-include = true
 
 [bd5b085e-f612-4f81-97a8-6314258278b0]
 description = "slices of a long series"
-include = true
 
 [6d235d85-46cf-4fae-9955-14b6efef27cd]
 description = "slice length is too large"
-include = true
 
 [d34004ad-8765-4c09-8ba1-ada8ce776806]
 description = "slice length cannot be zero"
-include = true
 
 [10ab822d-8410-470a-a85d-23fbeb549e54]
 description = "slice length cannot be negative"
-include = true
 
 [c7ed0812-0e4b-4bf3-99c4-28cbbfc246a2]
 description = "empty series is invalid"
-include = true

--- a/exercises/practice/sieve/.meta/tests.toml
+++ b/exercises/practice/sieve/.meta/tests.toml
@@ -4,20 +4,15 @@
 
 [88529125-c4ce-43cc-bb36-1eb4ddd7b44f]
 description = "no primes under two"
-include = true
 
 [4afe9474-c705-4477-9923-840e1024cc2b]
 description = "find first prime"
-include = true
 
 [974945d8-8cd9-4f00-9463-7d813c7f17b7]
 description = "find primes up to 10"
-include = true
 
 [2e2417b7-3f3a-452a-8594-b9af08af6d82]
 description = "limit is prime"
-include = true
 
 [92102a05-4c7c-47de-9ed0-b7d5fcd00f21]
 description = "find primes up to 1000"
-include = true

--- a/exercises/practice/space-age/.meta/tests.toml
+++ b/exercises/practice/space-age/.meta/tests.toml
@@ -4,32 +4,24 @@
 
 [84f609af-5a91-4d68-90a3-9e32d8a5cd34]
 description = "age on Earth"
-include = true
 
 [ca20c4e9-6054-458c-9312-79679ffab40b]
 description = "age on Mercury"
-include = true
 
 [502c6529-fd1b-41d3-8fab-65e03082b024]
 description = "age on Venus"
-include = true
 
 [9ceadf5e-a0d5-4388-9d40-2c459227ceb8]
 description = "age on Mars"
-include = true
 
 [42927dc3-fe5e-4f76-a5b5-f737fc19bcde]
 description = "age on Jupiter"
-include = true
 
 [8469b332-7837-4ada-b27c-00ee043ebcad]
 description = "age on Saturn"
-include = true
 
 [999354c1-76f8-4bb5-a672-f317b6436743]
 description = "age on Uranus"
-include = true
 
 [80096d30-a0d4-4449-903e-a381178355d8]
 description = "age on Neptune"
-include = true

--- a/exercises/practice/spiral-matrix/.meta/tests.toml
+++ b/exercises/practice/spiral-matrix/.meta/tests.toml
@@ -4,24 +4,18 @@
 
 [8f584201-b446-4bc9-b132-811c8edd9040]
 description = "empty spiral"
-include = true
 
 [e40ae5f3-e2c9-4639-8116-8a119d632ab2]
 description = "trivial spiral"
-include = true
 
 [cf05e42d-eb78-4098-a36e-cdaf0991bc48]
 description = "spiral of size 2"
-include = true
 
 [1c475667-c896-4c23-82e2-e033929de939]
 description = "spiral of size 3"
-include = true
 
 [05ccbc48-d891-44f5-9137-f4ce462a759d]
 description = "spiral of size 4"
-include = true
 
 [f4d2165b-1738-4e0c-bed0-c459045ae50d]
 description = "spiral of size 5"
-include = true

--- a/exercises/practice/sublist/.meta/tests.toml
+++ b/exercises/practice/sublist/.meta/tests.toml
@@ -4,68 +4,51 @@
 
 [97319c93-ebc5-47ab-a022-02a1980e1d29]
 description = "empty lists"
-include = true
 
 [de27dbd4-df52-46fe-a336-30be58457382]
 description = "empty list within non empty list"
-include = true
 
 [5487cfd1-bc7d-429f-ac6f-1177b857d4fb]
 description = "non empty list contains empty list"
-include = true
 
 [1f390b47-f6b2-4a93-bc23-858ba5dda9a6]
 description = "list equals itself"
-include = true
 
 [7ed2bfb2-922b-4363-ae75-f3a05e8274f5]
 description = "different lists"
-include = true
 
 [3b8a2568-6144-4f06-b0a1-9d266b365341]
 description = "false start"
-include = true
 
 [dc39ed58-6311-4814-be30-05a64bc8d9b1]
 description = "consecutive"
-include = true
 
 [d1270dab-a1ce-41aa-b29d-b3257241ac26]
 description = "sublist at start"
-include = true
 
 [81f3d3f7-4f25-4ada-bcdc-897c403de1b6]
 description = "sublist in middle"
-include = true
 
 [43bcae1e-a9cf-470e-923e-0946e04d8fdd]
 description = "sublist at end"
-include = true
 
 [76cf99ed-0ff0-4b00-94af-4dfb43fe5caa]
 description = "at start of superlist"
-include = true
 
 [b83989ec-8bdf-4655-95aa-9f38f3e357fd]
 description = "in middle of superlist"
-include = true
 
 [26f9f7c3-6cf6-4610-984a-662f71f8689b]
 description = "at end of superlist"
-include = true
 
 [0a6db763-3588-416a-8f47-76b1cedde31e]
 description = "first list missing element from second list"
-include = true
 
 [83ffe6d8-a445-4a3c-8795-1e51a95e65c3]
 description = "second list missing element from first list"
-include = true
 
 [0d7ee7c1-0347-45c8-9ef5-b88db152b30b]
 description = "order matters to a list"
-include = true
 
 [5f47ce86-944e-40f9-9f31-6368aad70aa6]
 description = "same digits but different numbers"
-include = true

--- a/exercises/practice/sum-of-multiples/.meta/tests.toml
+++ b/exercises/practice/sum-of-multiples/.meta/tests.toml
@@ -4,64 +4,48 @@
 
 [54aaab5a-ce86-4edc-8b40-d3ab2400a279]
 description = "no multiples within limit"
-include = true
 
 [361e4e50-c89b-4f60-95ef-5bc5c595490a]
 description = "one factor has multiples within limit"
-include = true
 
 [e644e070-040e-4ae0-9910-93c69fc3f7ce]
 description = "more than one multiple within limit"
-include = true
 
 [607d6eb9-535c-41ce-91b5-3a61da3fa57f]
 description = "more than one factor with multiples within limit"
-include = true
 
 [f47e8209-c0c5-4786-b07b-dc273bf86b9b]
 description = "each multiple is only counted once"
-include = true
 
 [28c4b267-c980-4054-93e9-07723db615ac]
 description = "a much larger limit"
-include = true
 
 [09c4494d-ff2d-4e0f-8421-f5532821ee12]
 description = "three factors"
-include = true
 
 [2d0d5faa-f177-4ad6-bde9-ebb865083751]
 description = "factors not relatively prime"
-include = true
 
 [ece8f2e8-96aa-4166-bbb7-6ce71261e354]
 description = "some pairs of factors relatively prime and some not"
-include = true
 
 [624fdade-6ffb-400e-8472-456a38c171c0]
 description = "one factor is a multiple of another"
-include = true
 
 [949ee7eb-db51-479c-b5cb-4a22b40ac057]
 description = "much larger factors"
-include = true
 
 [41093673-acbd-482c-ab80-d00a0cbedecd]
 description = "all numbers are multiples of 1"
-include = true
 
 [1730453b-baaa-438e-a9c2-d754497b2a76]
 description = "no factors means an empty sum"
-include = true
 
 [214a01e9-f4bf-45bb-80f1-1dce9fbb0310]
 description = "the only multiple of 0 is 0"
-include = true
 
 [c423ae21-a0cb-4ec7-aeb1-32971af5b510]
 description = "the factor 0 does not affect the sum of multiples of other factors"
-include = true
 
 [17053ba9-112f-4ac0-aadb-0519dd836342]
 description = "solutions using include-exclude must extend to cardinality greater than 3"
-include = true

--- a/exercises/practice/transpose/.meta/tests.toml
+++ b/exercises/practice/transpose/.meta/tests.toml
@@ -4,48 +4,36 @@
 
 [404b7262-c050-4df0-a2a2-0cb06cd6a821]
 description = "empty string"
-include = true
 
 [a89ce8a3-c940-4703-a688-3ea39412fbcb]
 description = "two characters in a row"
-include = true
 
 [855bb6ae-4180-457c-abd0-ce489803ce98]
 description = "two characters in a column"
-include = true
 
 [5ceda1c0-f940-441c-a244-0ced197769c8]
 description = "simple"
-include = true
 
 [a54675dd-ae7d-4a58-a9c4-0c20e99a7c1f]
 description = "single line"
-include = true
 
 [0dc2ec0b-549d-4047-aeeb-8029fec8d5c5]
 description = "first line longer than second line"
-include = true
 
 [984e2ec3-b3d3-4b53-8bd6-96f5ef404102]
 description = "second line longer than first line"
-include = true
 
 [eccd3784-45f0-4a3f-865a-360cb323d314]
 description = "mixed line length"
-include = true
 
 [85b96b3f-d00c-4f80-8ca2-c8a5c9216c2d]
 description = "square"
-include = true
 
 [b9257625-7a53-4748-8863-e08e9d27071d]
 description = "rectangle"
-include = true
 
 [b80badc9-057e-4543-bd07-ce1296a1ea2c]
 description = "triangle"
-include = true
 
 [76acfd50-5596-4d05-89f1-5116328a7dd9]
 description = "jagged triangle"
-include = true

--- a/exercises/practice/triangle/.meta/tests.toml
+++ b/exercises/practice/triangle/.meta/tests.toml
@@ -4,76 +4,57 @@
 
 [8b2c43ac-7257-43f9-b552-7631a91988af]
 description = "all sides are equal"
-include = true
 
 [33eb6f87-0498-4ccf-9573-7f8c3ce92b7b]
 description = "any side is unequal"
-include = true
 
 [c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87]
 description = "no sides are equal"
-include = true
 
 [16e8ceb0-eadb-46d1-b892-c50327479251]
 description = "all zero sides is not a triangle"
-include = true
 
 [3022f537-b8e5-4cc1-8f12-fd775827a00c]
 description = "sides may be floats"
-include = true
 
 [cbc612dc-d75a-4c1c-87fc-e2d5edd70b71]
 description = "last two sides are equal"
-include = true
 
 [e388ce93-f25e-4daf-b977-4b7ede992217]
 description = "first two sides are equal"
-include = true
 
 [d2080b79-4523-4c3f-9d42-2da6e81ab30f]
 description = "first and last sides are equal"
-include = true
 
 [8d71e185-2bd7-4841-b7e1-71689a5491d8]
 description = "equilateral triangles are also isosceles"
-include = true
 
 [840ed5f8-366f-43c5-ac69-8f05e6f10bbb]
 description = "no sides are equal"
-include = true
 
 [2eba0cfb-6c65-4c40-8146-30b608905eae]
 description = "first triangle inequality violation"
-include = true
 
 [278469cb-ac6b-41f0-81d4-66d9b828f8ac]
 description = "second triangle inequality violation"
-include = true
 
 [90efb0c7-72bb-4514-b320-3a3892e278ff]
 description = "third triangle inequality violation"
-include = true
 
 [adb4ee20-532f-43dc-8d31-e9271b7ef2bc]
 description = "sides may be floats"
-include = true
 
 [e8b5f09c-ec2e-47c1-abec-f35095733afb]
 description = "no sides are equal"
-include = true
 
 [2510001f-b44d-4d18-9872-2303e7977dc1]
 description = "all sides are equal"
-include = true
 
 [c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e]
 description = "two sides are equal"
-include = true
 
 [70ad5154-0033-48b7-af2c-b8d739cd9fdc]
 description = "may not violate triangle inequality"
-include = true
 
 [26d9d59d-f8f1-40d3-ad58-ae4d54123d7d]
 description = "sides may be floats"
-include = true

--- a/exercises/practice/two-fer/.meta/tests.toml
+++ b/exercises/practice/two-fer/.meta/tests.toml
@@ -4,12 +4,9 @@
 
 [1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce]
 description = "no name given"
-include = true
 
 [b4c6dbb8-b4fb-42c2-bafd-10785abe7709]
 description = "a name given"
-include = true
 
 [3549048d-1a6e-4653-9a79-b0bda163e8d5]
 description = "another name given"
-include = true

--- a/exercises/practice/word-count/.meta/tests.toml
+++ b/exercises/practice/word-count/.meta/tests.toml
@@ -4,52 +4,39 @@
 
 [61559d5f-2cad-48fb-af53-d3973a9ee9ef]
 description = "count one word"
-include = true
 
 [5abd53a3-1aed-43a4-a15a-29f88c09cbbd]
 description = "count one of each word"
-include = true
 
 [2a3091e5-952e-4099-9fac-8f85d9655c0e]
 description = "multiple occurrences of a word"
-include = true
 
 [e81877ae-d4da-4af4-931c-d923cd621ca6]
 description = "handles cramped lists"
-include = true
 
 [7349f682-9707-47c0-a9af-be56e1e7ff30]
 description = "handles expanded lists"
-include = true
 
 [a514a0f2-8589-4279-8892-887f76a14c82]
 description = "ignore punctuation"
-include = true
 
 [d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e]
 description = "include numbers"
-include = true
 
 [dac6bc6a-21ae-4954-945d-d7f716392dbf]
 description = "normalize case"
-include = true
 
 [4185a902-bdb0-4074-864c-f416e42a0f19]
 description = "with apostrophes"
-include = true
 
 [be72af2b-8afe-4337-b151-b297202e4a7b]
 description = "with quotations"
-include = true
 
 [8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6]
 description = "substrings from the beginning"
-include = true
 
 [c5f4ef26-f3f7-4725-b314-855c04fb4c13]
 description = "multiple spaces not detected as a word"
-include = true
 
 [50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360]
 description = "alternating word separators not detected as a word"
-include = true


### PR DESCRIPTION
This PR simplifies the `tests.toml` files by removing any `include = true` properties, which are redundant as the default value of this field is `true`.

As the vast majority of the test cases use `include = true`, omitting it makes the `tests.toml` files more readable and make the exceptional cases (`include = false`) easier to identify.

We've updated `configlet` to use this new behavior. See https://github.com/exercism/configlet/issues/186 and https://github.com/exercism/configlet/issues/207 for the corresponding discussion.

## Tracking

https://github.com/exercism/v3-launch/issues/31
