### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/src/hello_world.erl
+++ b/exercises/practice/hello-world/src/hello_world.erl
@@ -2,5 +2,5 @@
 
 -export([hello/0]).
 
-
-hello() -> undefined.
+hello() ->
+  "Goodbye, Mars!".


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46
