### PR TITLE
Use builtin map to list function.

### DIFF
--- a/exercises/practice/parallel-letter-frequency/test/parallel_letter_frequency_tests.erl
+++ b/exercises/practice/parallel-letter-frequency/test/parallel_letter_frequency_tests.erl
@@ -7,4 +7,4 @@ single_test() ->
   ?assert( parallel_letter_frequency:dict(["asd"]) =:= #{$a => 1, $d => 1, $s => 1} ).
 
 double_test() ->
-  ?assert(  parallel_letter_frequency:dict(["asd", "asd"]) =:= #{$a => 2, $d => 2, $s => 2} ).
+  ?assert( parallel_letter_frequency:dict(["asd", "asd"]) =:= #{$a => 2, $d => 2, $s => 2} ).

--- a/exercises/practice/parallel-letter-frequency/test/parallel_letter_frequency_tests.erl
+++ b/exercises/practice/parallel-letter-frequency/test/parallel_letter_frequency_tests.erl
@@ -4,9 +4,9 @@
 -include_lib("eunit/include/eunit.hrl").
 
 single_test() ->
-  Frequencies = dict:to_list( parallel_letter_frequency:dict(["asd"]) ),
+  Frequencies = maps:to_list( parallel_letter_frequency:dict(["asd"]) ),
   ?assert( lists:sort(Frequencies) =:= [{$a,1},{$d,1},{$s,1}] ).
 
 double_test() ->
-  Frequencies = dict:to_list( parallel_letter_frequency:dict(["asd", "asd"]) ),
+  Frequencies = maps:to_list( parallel_letter_frequency:dict(["asd", "asd"]) ),
   ?assert( lists:sort(Frequencies) =:= [{$a,2},{$d,2},{$s,2}] ).

--- a/exercises/practice/parallel-letter-frequency/test/parallel_letter_frequency_tests.erl
+++ b/exercises/practice/parallel-letter-frequency/test/parallel_letter_frequency_tests.erl
@@ -4,9 +4,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 single_test() ->
-  Frequencies = maps:to_list( parallel_letter_frequency:dict(["asd"]) ),
-  ?assert( lists:sort(Frequencies) =:= [{$a,1},{$d,1},{$s,1}] ).
+  ?assert( parallel_letter_frequency:dict(["asd"]) =:= #{$a => 1, $d => 1, $s => 1} ).
 
 double_test() ->
-  Frequencies = maps:to_list( parallel_letter_frequency:dict(["asd", "asd"]) ),
-  ?assert( lists:sort(Frequencies) =:= [{$a,2},{$d,2},{$s,2}] ).
+  ?assert(  parallel_letter_frequency:dict(["asd", "asd"]) =:= #{$a => 2, $d => 2, $s => 2} ).

--- a/exercises/practice/parallel-letter-frequency/test/parallel_letter_frequency_tests.erl
+++ b/exercises/practice/parallel-letter-frequency/test/parallel_letter_frequency_tests.erl
@@ -1,10 +1,16 @@
--module( parallel_letter_frequency_tests ).
+-module(parallel_letter_frequency_tests).
 
 -include_lib("erl_exercism/include/exercism.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 single_test() ->
-  ?assert( parallel_letter_frequency:dict(["asd"]) =:= #{$a => 1, $d => 1, $s => 1} ).
+    ?assertEqual(
+        parallel_letter_frequency:dict(["asd"]),
+        dict:from_list([{$a, 1}, {$d, 1}, {$s, 1}])
+    ).
 
 double_test() ->
-  ?assert( parallel_letter_frequency:dict(["asd", "asd"]) =:= #{$a => 2, $d => 2, $s => 2} ).
+    ?assertEqual(
+        parallel_letter_frequency:dict(["asd", "asd"]),
+        dict:from_list([{$a, 2}, {$d, 2}, {$s, 2}])
+    ).


### PR DESCRIPTION
The tests currently rely on a function not sketched in `dict:to_list`. Furthermore this function is easily provided by the standard library and it is secondary to the objective of this exercise.

So we should either:

*   Add that function to [parallel_letter_frequency_tests.erl](https://github.com/exercism/erlang/blob/main/exercises/practice/parallel-letter-frequency/test/parallel_letter_frequency_tests.erl).

*   Use the builtin `maps:to_list` function on the existing tests (I chose this route).

(Do I need to change the code elsewhere?)