### PR TITLE
Remove reference to Gitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Exercism Erlang Track
 
-[![Join the chat at https://gitter.im/exercism/erlang](https://badges.gitter.im/exercism/erlang.svg)](https://gitter.im/exercism/erlang?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
 Exercism exercises in Erlang
 
 ## Contributing guide

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,8 +1,5 @@
 # Installation
 
-If you have any trouble installing erlang please consider joining the 
-[gitter support channel](https://gitter.im/exercism/xerlang)
-
 ## Homebrew for Mac OS X
 
 Update your Homebrew to latest:

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -2,7 +2,6 @@
 
 Exercism provides exercises and feedback but can be difficult to jump into for those learning Erlang for the first time. These resources can help you get started:
 
-* [Exercism related BEAM support channel on gitter](https://gitter.im/exercism/xerlang)
 * [Erlang Documentation](http://www.erlang.org/doc.html)
 * [Learn You Some Erlang for Great Good](http://learnyousomeerlang.com)
 * [StackOverflow](http://stackoverflow.com/)

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -2,7 +2,6 @@
 
 To get help if you're having trouble, you can use one of the following resources:
 
-- [Exercism related BEAM support channel on gitter](https://gitter.im/exercism/xerlang)
 - [Erlang Documentation](http://www.erlang.org/doc.html)
 - [Learn You Some Erlang for Great Good](http://learnyousomeerlang.com)
 - [StackOverflow](http://stackoverflow.com/)


### PR DESCRIPTION
The Exerism Forum (https://forum.exercism.org/) has now made Gitter redundant.
We're directing everyone there.
