### PR TITLE
Implementation of the resistor-color exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -955,6 +955,15 @@
         "prerequisites": [],
         "difficulty": 3,
         "topics": []
+      },
+      {
+        "slug": "resistor-color",
+        "name": "Resistor Color",
+        "uuid": "0cba2715-411b-4f75-87e6-7d79009b320d",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1,
+        "topics": []
       }
     ],
     "foregone": [

--- a/exercises/practice/resistor-color/.docs/instructions.md
+++ b/exercises/practice/resistor-color/.docs/instructions.md
@@ -1,0 +1,39 @@
+# Instructions
+
+If you want to build something using a Raspberry Pi, you'll probably use _resistors_.
+For this exercise, you need to know two things about them:
+
+- Each resistor has a resistance value.
+- Resistors are small - so small in fact that if you printed the resistance value on them, it would be hard to read.
+
+To get around this problem, manufacturers print color-coded bands onto the resistors to denote their resistance values.
+Each band has a position and a numeric value.
+
+The first 2 bands of a resistor have a simple encoding scheme: each color maps to a single number.
+
+In this exercise you are going to create a helpful program so that you don't have to remember the values of the bands.
+
+These colors are encoded as follows:
+
+- Black: 0
+- Brown: 1
+- Red: 2
+- Orange: 3
+- Yellow: 4
+- Green: 5
+- Blue: 6
+- Violet: 7
+- Grey: 8
+- White: 9
+
+The goal of this exercise is to create a way:
+
+- to look up the numerical value associated with a particular color band
+- to list the different band colors
+
+Mnemonics map the colors to the numbers, that, when stored as an array, happen to map to their index in the array:
+Better Be Right Or Your Great Big Values Go Wrong.
+
+More information on the color encoding of resistors can be found in the [Electronic color code Wikipedia article][e-color-code].
+
+[e-color-code]: https://en.wikipedia.org/wiki/Electronic_color_code

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -1,0 +1,17 @@
+{
+  "authors": [],
+  "files": {
+    "solution": [
+      "src/resistor_color.erl"
+    ],
+    "test": [
+      "test/resistor_color_tests.erl"
+    ],
+    "example": [
+      ".meta/example.erl"
+    ]
+  },
+  "blurb": "Convert a resistor band's color to its numeric representation.",
+  "source": "Maud de Vries, Erik Schierboom",
+  "source_url": "https://github.com/exercism/problem-specifications/issues/1458"
+}

--- a/exercises/practice/resistor-color/.meta/example.erl
+++ b/exercises/practice/resistor-color/.meta/example.erl
@@ -1,0 +1,28 @@
+-module(example).
+
+-export([colors/0, color_code/1]).
+
+colors() ->
+    [
+        black,
+	brown,
+	red,
+	orange,
+	yellow,
+	green,
+	blue,
+	violet,
+	grey,
+	white
+    ].
+
+color_code(black) -> 0;
+color_code(brown) -> 1;
+color_code(red) -> 2;
+color_code(orange) -> 3;
+color_code(yellow) -> 4;
+color_code(green) -> 5;
+color_code(blue) -> 6;
+color_code(violet) -> 7;
+color_code(grey) -> 8;
+color_code(white) -> 9.

--- a/exercises/practice/resistor-color/.meta/tests.toml
+++ b/exercises/practice/resistor-color/.meta/tests.toml
@@ -1,0 +1,22 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[49eb31c5-10a8-4180-9f7f-fea632ab87ef]
+description = "Color codes -> Black"
+
+[0a4df94b-92da-4579-a907-65040ce0b3fc]
+description = "Color codes -> White"
+
+[5f81608d-f36f-4190-8084-f45116b6f380]
+description = "Color codes -> Orange"
+
+[581d68fa-f968-4be2-9f9d-880f2fb73cf7]
+description = "Colors"

--- a/exercises/practice/resistor-color/rebar.config
+++ b/exercises/practice/resistor-color/rebar.config
@@ -1,0 +1,30 @@
+%% Erlang compiler options
+{erl_opts, [debug_info, warnings_as_errors]}.
+
+{deps, [{erl_exercism, "0.1.2"}]}.
+
+{dialyzer, [
+  {warnings, [underspecs, no_return]},
+  {get_warnings, true},
+  {plt_apps, top_level_deps}, % top_level_deps | all_deps
+  {plt_extra_apps, []},
+  {plt_location, local}, % local | "/my/file/name"
+  {plt_prefix, "rebar3"},
+  {base_plt_apps, [stdlib, kernel, crypto]},
+  {base_plt_location, global}, % global | "/my/file/name"
+  {base_plt_prefix, "rebar3"}
+]}.
+
+%% eunit:test(Tests)
+{eunit_tests, []}.
+%% Options for eunit:test(Tests, Opts)
+{eunit_opts, [verbose]}.
+
+%% == xref ==
+
+{xref_warnings, true}.
+
+%% xref checks to run
+{xref_checks, [undefined_function_calls, undefined_functions,
+  locals_not_used, exports_not_used,
+  deprecated_function_calls, deprecated_functions]}.

--- a/exercises/practice/resistor-color/src/resistor_color.app.src
+++ b/exercises/practice/resistor-color/src/resistor_color.app.src
@@ -1,0 +1,9 @@
+{application, resistor_color,
+  [{description, "exercism.io - resistor color"},
+    {vsn, "0.0.1"},
+    {modules, []},
+    {registered, []},
+    {applications, [kernel,
+      stdlib]},
+    {env, []}
+  ]}.

--- a/exercises/practice/resistor-color/src/resistor_color.erl
+++ b/exercises/practice/resistor-color/src/resistor_color.erl
@@ -1,0 +1,9 @@
+-module(resistor_color).
+
+-export([colors/0, color_code/1]).
+
+colors() ->
+    undefined.
+
+color_code(_Color) ->
+    undefined.

--- a/exercises/practice/resistor-color/test/resistor_color_tests.erl
+++ b/exercises/practice/resistor-color/test/resistor_color_tests.erl
@@ -1,0 +1,33 @@
+-module(resistor_color_tests).
+
+-include_lib("erl_exercism/include/exercism.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+
+
+
+'1_color_codes_black_test_'() ->
+    Input = black,
+    Expected = 0,
+    {"black",
+     ?_assertEqual(Expected,
+                   resistor_color:color_code(Input))}.
+
+'2_color_codes_white_test_'() ->
+    Input = white,
+    Expected = 9,
+    {"white",
+     ?_assertEqual(Expected,
+                   resistor_color:color_code(Input))}.
+
+'3_color_codes_orange_test_'() ->
+    Input = orange,
+    Expected = 3,
+    {"orange",
+     ?_assertEqual(Expected,
+                   resistor_color:color_code(Input))}.
+
+'4_colors_test_'() ->
+    {"colors",
+     ?_assertEqual([black, brown, red, orange, yellow, green, blue, violet, grey, white],
+                   resistor_color:colors())}.


### PR DESCRIPTION
This PR provides the `resistor-color` exercise for the Erlang track.

On a side note, the contribution guidelines are out of date.
So is the `check-exercises` escript, which looks for the exercises directly under `exercises/`, but they (now) live one level deeper. Accordingly, it will fail.