### PR TITLE
fix OTP release discovery

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       env: 
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        all_versions=$(gh api graphql -f query='query { repository(owner: "erlang", name: "otp") { releases(last: 100) { nodes { tagName } } } }' --jq '.data.repository.releases.nodes[].tagName | select(. | contains("rc") | not) | .[4:8]' | sort -u -n)
+        all_versions=$(gh api graphql -f query='query { repository(owner: "erlang", name: "otp") { releases(last: 100, orderBy: {field: CREATED_AT, direction: ASC}) { nodes { tagName } } } }' --jq '.data.repository.releases.nodes[].tagName | select(. | contains("rc") | not) | .[4:8]' | sort -u -n)
         latest_versions=$(./bin/get_latest_majors_for_ci_matrix.py <<< "$all_versions")
         printf "::set-output name=versions::%s" "$latest_versions"
 


### PR DESCRIPTION
It seems as if GitHub changed the default ordering of releases in the API (or the ordering wasn't to rely on in the first place).

This PR fixes this by explicitely setting the expected ordering in the query.