### PR TITLE
CI: pin GitHub Actions runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   create_otp_matrix:
     name: Generate a list of last OTP versions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       otps: ${{ steps.versions.outputs.versions }}
     steps:
@@ -22,7 +22,7 @@ jobs:
 
   test_erlang:
     name: Test examples against OTP ${{ matrix.otp }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [create_otp_matrix]
     strategy:
       matrix:

--- a/.github/workflows/uuid.yml
+++ b/.github/workflows/uuid.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   uuid:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
     - run: sudo apt install --yes jq


### PR DESCRIPTION
This PR updates GitHub Actions runners to a specific version.
This ensures that the workflow will always run on the same runner, which makes your build _stable_.

The PR updates the *-latest version with the current version, as specified in https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-test-runners-to-version for more information.