### PR TITLE
Add missing author to resistor-color config.json

### DIFF
--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -1,5 +1,7 @@
 {
-  "authors": [],
+  "authors": [
+    "juhlig"
+  ],
   "files": {
     "solution": [
       "src/resistor_color.erl"


### PR DESCRIPTION
I noticed the exercise author wasn't set for resistor-color. Feel free to label this fix as `rep/tiny`.