### PR TITLE
Update OTP version retrieval

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       env: 
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        all_versions=$(gh api graphql -f query='query { repository(owner: "erlang", name: "otp") { releases(last: 100, orderBy: {field: CREATED_AT, direction: ASC}) { nodes { tagName } } } }' --jq '.data.repository.releases.nodes[].tagName | select(. | contains("rc") | not) | .[4:8]' | sort -u -n)
+        all_versions=$(gh api graphql -f query='query { repository(owner: "erlang", name: "otp") { releases(last: 100, orderBy: {field: CREATED_AT, direction: ASC}) { nodes { tagName } } } }' --jq '.data.repository.releases.nodes[].tagName | select(. | contains("rc") | not) | .[4:8] | select(test("^[0-9]+\\.[0-9]+$"))' | sort -u -n)
         latest_versions=$(./bin/get_latest_majors_for_ci_matrix.py <<< "$all_versions")
         printf "::set-output name=versions::%s" "$latest_versions"
 


### PR DESCRIPTION
Needed to merge in #600.

Before this fix, the `gh api` query was pulling in a `h-ba` for the version list. That broke `bin/get_latest_majors_for_ci_matrix.py` when it tried to split that name on a period to get the major and minor version for the OTP matrix.