### PR TITLE
Fix `square-root` stub function name

### DIFF
--- a/exercises/practice/square-root/src/square_root.erl
+++ b/exercises/practice/square-root/src/square_root.erl
@@ -3,4 +3,4 @@
 -export([square_root/1]).
 
 
-square(_Radicand) -> undefined.
+square_root(_Radicand) -> undefined.


### PR DESCRIPTION
Fixes a CI breakage introduced by #600 being merged without being tested (my bad!).