### PR TITLE
Use assertMatch instead of assert

### DIFF
--- a/exercises/practice/bank-account/test/bank_account_tests.erl
+++ b/exercises/practice/bank-account/test/bank_account_tests.erl
@@ -5,52 +5,52 @@
 
 create_test() ->
   BankAccount = bank_account:create(),
-  ?assert(bank_account:balance(BankAccount) =:= 0).
+  ?assertMatch(0, bank_account:balance(BankAccount)).
 
 close_account_test() ->
   BankAccount = bank_account:create(),
   bank_account:deposit(BankAccount, 1),
   Amount = bank_account:close(BankAccount),
-  ?assert(Amount =:= 1),
-  ?assertEqual({error, account_closed}, bank_account:balance( BankAccount )).
+  ?assertMatch(1, Amount),
+  ?assertMatch({error, account_closed}, bank_account:balance(BankAccount)).
 
 deposit_test() ->
   BankAccount = bank_account:create(),
   bank_account:deposit(BankAccount, 1),
-  ?assert(bank_account:balance(BankAccount) =:= 1).
+  ?assertMatch(1, bank_account:balance(BankAccount)).
 
 deposit_fail_test() ->
   BankAccount = bank_account:create(),
   bank_account:deposit(BankAccount, -1),
-  ?assert(bank_account:balance(BankAccount) =:= 0).
+  ?assertMatch(0, bank_account:balance(BankAccount)).
 
 deposit_many_test() ->
   BankAccount = bank_account:create(),
   [erlang:spawn( fun () -> bank_account:deposit(BankAccount, X) end ) || X <- lists:seq(1, 10)],
   timer:sleep(100),
   Last = bank_account:balance(BankAccount),
-  ?assert(Last =:= 55).
+  ?assertMatch(55, Last).
 
 withdraw_test() ->
   BankAccount = bank_account:create(),
   bank_account:deposit(BankAccount, 10 ),
   Amount = bank_account:withdraw(BankAccount, 1),
-  ?assert(Amount =:= 1),
-  ?assert(bank_account:balance(BankAccount) =:= 9).
+  ?assertMatch(1, Amount),
+  ?assertMatch(9, bank_account:balance(BankAccount)).
 
 withdraw_fail_test() ->
   BankAccount = bank_account:create(),
   bank_account:deposit(BankAccount, 10),
   Amount = bank_account:withdraw(BankAccount, -1),
-  ?assert(Amount =:= 0),
-  ?assert(bank_account:balance(BankAccount) =:= 10).
+  ?assertMatch(0, Amount),
+  ?assertMatch(10, bank_account:balance(BankAccount)).
 
 withdraw_excessive_test() ->
   BankAccount = bank_account:create(),
   bank_account:deposit(BankAccount, 10 ),
   Amount = bank_account:withdraw(BankAccount, 20),
-  ?assert(Amount =:= 10),
-  ?assert(bank_account:balance(BankAccount) =:= 0).
+  ?assertMatch(10, Amount),
+  ?assertMatch(0, bank_account:balance(BankAccount)).
 
 withdraw_many_test() ->
   BankAccount = bank_account:create(),
@@ -58,28 +58,28 @@ withdraw_many_test() ->
   [erlang:spawn( fun () -> bank_account:withdraw(BankAccount, X) end ) || X <- lists:seq(1, 10)],
   timer:sleep(100),
   Last = bank_account:balance(BankAccount),
-  ?assert(Last =:= 0).
+  ?assertMatch(0, Last).
 
 charge_test() ->
   BankAccount = bank_account:create(),
   bank_account:deposit(BankAccount, 10),
   Amount = bank_account:charge(BankAccount, 2),
-  ?assert(Amount =:= 2),
-  ?assert(bank_account:balance(BankAccount) =:= 8).
+  ?assertMatch(2, Amount),
+  ?assertMatch(8, bank_account:balance(BankAccount)).
 
 charge_fail_test() ->
   BankAccount = bank_account:create(),
   bank_account:deposit(BankAccount, 10),
   Amount = bank_account:charge(BankAccount, -2),
-  ?assert(Amount =:= 0),
-  ?assert(bank_account:balance(BankAccount) =:= 10).
+  ?assertMatch(0, Amount),
+  ?assertMatch(10, bank_account:balance(BankAccount)).
 
 charge_excessive_test() ->
   BankAccount = bank_account:create(),
   bank_account:deposit(BankAccount, 10),
   Amount = bank_account:charge(BankAccount, 20),
-  ?assert(Amount =:= 0),
-  ?assert(bank_account:balance(BankAccount) =:= 10).
+  ?assertMatch(0, Amount),
+  ?assertMatch(10, bank_account:balance(BankAccount)).
 
 charge_many_test() ->
   BankAccount = bank_account:create(),
@@ -87,4 +87,4 @@ charge_many_test() ->
   [erlang:spawn( fun () -> bank_account:charge(BankAccount, 10) end ) || _X <- lists:seq(1, 10)],
   timer:sleep(100),
   Last = bank_account:balance(BankAccount),
-  ?assert(Last =:= 5).
+  ?assertMatch(5, Last).

--- a/exercises/practice/circular-buffer/test/circular_buffer_tests.erl
+++ b/exercises/practice/circular-buffer/test/circular_buffer_tests.erl
@@ -5,22 +5,22 @@
 
 create_test() ->
   Pid = circular_buffer:create( 5 ),
-  ?assert( {ok, 5} =:= circular_buffer:size(Pid) ).
+  ?assertMatch( {ok, 5}, circular_buffer:size(Pid) ).
 
 write_read_test() ->
   Pid = circular_buffer:create( 4 ),
-  ?assert( {error, empty} =:= circular_buffer:read(Pid) ),
+  ?assertMatch( {error, empty}, circular_buffer:read(Pid) ),
   circular_buffer:write( Pid, 1 ),
-  ?assert( {ok, 1} =:= circular_buffer:read(Pid) ).
+  ?assertMatch( {ok, 1}, circular_buffer:read(Pid) ).
 
 write_read_many_test() ->
   Pid = circular_buffer:create( 3 ),
   circular_buffer:write( Pid, 1 ),
   circular_buffer:write( Pid, 2 ),
   circular_buffer:write( Pid, 3 ),
-  ?assert( {ok, 1} =:= circular_buffer:read(Pid) ),
-  ?assert( {ok, 2} =:= circular_buffer:read(Pid) ),
-  ?assert( {ok, 3} =:= circular_buffer:read(Pid) ).
+  ?assertMatch( {ok, 1}, circular_buffer:read(Pid) ),
+  ?assertMatch( {ok, 2}, circular_buffer:read(Pid) ),
+  ?assertMatch( {ok, 3}, circular_buffer:read(Pid) ).
 
 over_write_read_test() ->
   Pid = circular_buffer:create( 2 ),
@@ -28,17 +28,17 @@ over_write_read_test() ->
   circular_buffer:write( Pid, 2 ),
   circular_buffer:write( Pid, 3 ),
   circular_buffer:write( Pid, 4 ),
-  ?assert( {ok, 3} =:= circular_buffer:read(Pid) ),
-  ?assert( {ok, 4} =:= circular_buffer:read(Pid) ),
-  ?assert( {error, empty} =:= circular_buffer:read(Pid) ).
+  ?assertMatch( {ok, 3}, circular_buffer:read(Pid) ),
+  ?assertMatch( {ok, 4}, circular_buffer:read(Pid) ),
+  ?assertMatch( {error, empty}, circular_buffer:read(Pid) ).
 
 write_attempt_test() ->
   Pid = circular_buffer:create( 1 ),
   Attempt1 = circular_buffer:write_attempt( Pid, 1 ),
-  ?assert( ok =:= Attempt1 ),
+  ?assertMatch( ok, Attempt1 ),
   Attempt2 = circular_buffer:write_attempt( Pid, 2 ),
-  ?assert( {error, full} =:= Attempt2 ),
-  ?assert( {ok, 1} =:= circular_buffer:read(Pid) ).
+  ?assertMatch( {error, full}, Attempt2 ),
+  ?assertMatch( {ok, 1}, circular_buffer:read(Pid) ).
 
 producer_consumer_test() ->
   Pid = circular_buffer:create( 3 ),
@@ -53,4 +53,4 @@ producer_consumer_test() ->
   Reads = receive
             {Ref, R} -> R
           end,
-  ?assert( Reads =:= [{ok, 1}, {ok, 2}, {ok, 3}] ).
+  ?assertMatch( [{ok, 1}, {ok, 2}, {ok, 3}], Reads ).


### PR DESCRIPTION
As discussed in the [forum](https://forum.exercism.org/t/improving-assertions-in-erlangs-bank-account-and-circular-buffer-tests/13454/3).

This is to provide a better message when the assertion fails. assertMatch outputs the actual values instead of the expression that fails.

[no important files changed]