### PR TITLE
square_root_tests.erl typo [no important files changed]

### DIFF
--- a/exercises/practice/square-root/test/square_root_tests.erl
+++ b/exercises/practice/square-root/test/square_root_tests.erl
@@ -7,7 +7,7 @@
 
 
 '1_root_of_1_test_'() ->
-    {"root of l",
+    {"root of 1",
      ?_assertMatch(1, square_root:square_root(1))}.
 
 '2_root_of_4_test_'() ->


### PR DESCRIPTION
Tests in exercise `Square Root ` looks like so:
```erlang
'1_root_of_1_test_'() ->
    {"root of l",
     ?_assertMatch(1, square_root:square_root(1))}.
```
so there is small typo `root of l` - it should be  `root of 1` :smile_cat: 