### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 The anagrams can be returned in any order.

--- a/exercises/practice/complex-numbers/.docs/instructions.append.md
+++ b/exercises/practice/complex-numbers/.docs/instructions.append.md
@@ -1,4 +1,6 @@
 # Instructions append
 
+## Implementation
+
 You also need to implement a `equal/2` function. For this you can consider
 two numbers as equal, when the difference of each component is less than 0.005.

--- a/exercises/practice/hamming/.docs/instructions.append.md
+++ b/exercises/practice/hamming/.docs/instructions.append.md
@@ -1,1 +1,5 @@
+# Instructions append
+
+## Implementation
+
 If the sequences are not of equal length, return a tuple of `{error, badarg}`. Otherwise, return only the integer.

--- a/exercises/practice/robot-simulator/.docs/instructions.append.md
+++ b/exercises/practice/robot-simulator/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 This exercise does require some kind of global state for your
 robot. In erlang this can be done in various ways (starting with most
 idiomatic one):


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.